### PR TITLE
Fix invalid memory type handling and harden state parsing

### DIFF
--- a/backend/api/memory.py
+++ b/backend/api/memory.py
@@ -26,11 +26,11 @@ def get_character_memory(
 ):
     _require_character(character_id)
     ensure_memory_store(character_id)
-    return {
-        "character_id": character_id,
-        "state": load_character_state(character_id),
-        "memories": list_memories(character_id, memory_type=memory_type, limit=limit),
-    }
+    try:
+        memories = list_memories(character_id, memory_type=memory_type, limit=limit)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    return {"character_id": character_id, "state": load_character_state(character_id), "memories": memories}
 
 
 @router.get("/api/memory/{character_id}/search")
@@ -56,7 +56,10 @@ class MemoryClearRequest(BaseModel):
 @router.post("/api/memory/{character_id}/clear")
 def clear_character_memory(character_id: str, body: MemoryClearRequest):
     _require_character(character_id)
-    clear_memories(character_id, memory_type=body.memory_type)
+    try:
+        clear_memories(character_id, memory_type=body.memory_type)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
     state = None
     if body.reset_state:
         state = reset_character_state(character_id)

--- a/backend/services/memory_store.py
+++ b/backend/services/memory_store.py
@@ -90,6 +90,9 @@ def list_memories(
     memory_type: str | None = None,
     limit: int = 50,
 ) -> list[dict]:
+    if memory_type and memory_type not in MEMORY_FILES:
+        raise ValueError(f"Unsupported memory type: {memory_type}")
+
     memory_dir = ensure_memory_store(character_id, user_id)
     filenames = [MEMORY_FILES[memory_type]] if memory_type else list(MEMORY_FILES.values())
 
@@ -118,6 +121,9 @@ def clear_memories(
     user_id: str | None = None,
     memory_type: str | None = None,
 ) -> None:
+    if memory_type and memory_type not in MEMORY_FILES:
+        raise ValueError(f"Unsupported memory type: {memory_type}")
+
     memory_dir = ensure_memory_store(character_id, user_id)
     filenames = [MEMORY_FILES[memory_type]] if memory_type else list(MEMORY_FILES.values())
 

--- a/backend/services/state_store.py
+++ b/backend/services/state_store.py
@@ -13,6 +13,13 @@ def _clamp(value: float, minimum: float = 0.0, maximum: float = 1.0) -> float:
     return max(minimum, min(maximum, value))
 
 
+def _to_float(value: object, default: float) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
 def _state_path(character_id: str, user_id: str | None = None):
     ensure_memory_store(character_id, user_id)
     return get_memory_dir(character_id, user_id) / "state.json"
@@ -26,10 +33,10 @@ def load_character_state(character_id: str, user_id: str | None = None) -> dict:
         data = {}
 
     return {
-        "trust": float(data.get("trust", 0.0)),
-        "affection": float(data.get("affection", 0.0)),
+        "trust": _to_float(data.get("trust"), 0.0),
+        "affection": _to_float(data.get("affection"), 0.0),
         "mood": str(data.get("mood", "neutral")),
-        "energy": float(data.get("energy", 0.7)),
+        "energy": _to_float(data.get("energy"), 0.7),
         "relationship_summary": str(data.get("relationship_summary", "")).strip(),
         "updated_at": data.get("updated_at"),
     }
@@ -38,10 +45,10 @@ def load_character_state(character_id: str, user_id: str | None = None) -> dict:
 def save_character_state(character_id: str, state: dict, user_id: str | None = None) -> dict:
     current = load_character_state(character_id, user_id)
     merged = {
-        "trust": _clamp(float(state.get("trust", current["trust"]))),
-        "affection": _clamp(float(state.get("affection", current["affection"]))),
+        "trust": _clamp(_to_float(state.get("trust", current["trust"]), current["trust"])),
+        "affection": _clamp(_to_float(state.get("affection", current["affection"]), current["affection"])),
         "mood": str(state.get("mood", current["mood"])) or "neutral",
-        "energy": _clamp(float(state.get("energy", current["energy"]))),
+        "energy": _clamp(_to_float(state.get("energy", current["energy"]), current["energy"])),
         "relationship_summary": str(state.get("relationship_summary", current["relationship_summary"])).strip(),
         "updated_at": datetime.now(timezone.utc).isoformat(),
     }


### PR DESCRIPTION
### Motivation
- Prevent internal server errors when callers pass unsupported `memory_type` values and avoid crashes when persisted numeric state fields are malformed.
- Make memory-related endpoints return clear client errors and make character state loading/saving resilient to bad data.

### Description
- Add explicit `memory_type` validation in `list_memories` and `clear_memories` to raise `ValueError` for unsupported types instead of allowing a `KeyError` to bubble up (`backend/services/memory_store.py`).
- Convert memory API validation failures into HTTP 400 responses in `GET /api/memory/{character_id}` and `POST /api/memory/{character_id}/clear` (`backend/api/memory.py`).
- Introduce a safe float coercion helper `_to_float` and use it when loading and merging `trust`, `affection`, and `energy` so non-numeric persisted values are handled gracefully (`backend/services/state_store.py`).

### Testing
- Ran `python -m compileall backend` to ensure the backend modules compile successfully, which completed without errors.
- Ran a quick sanity check calling `list_memories('demo', memory_type='unknown')` and verified it raises a controlled `ValueError` with message "Unsupported memory type: unknown".

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e540dfbdc88332869599647443b9a8)