### PR TITLE
Improve README and add standard open-source community files

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,130 @@
+# Contributor Covenant Code of Conduct
+
+## Our pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others’ private information, such as a physical or email address,
+  without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement by opening an
+issue or discussion on this repository (avoid posting private or sensitive
+personal details in public threads), or by using [GitHub
+Support](https://support.github.com) for platform-level abuse.
+
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within
+the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+https://www.contributor-covenant.org/version/2/1/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by
+[Mozilla’s code of conduct enforcement ladder](https://github.com/mozilla/diversity).
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see
+https://www.contributor-covenant.org/faq

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,48 @@
+# Contributing
+
+Thank you for helping improve MeuxCompanion. This document explains how to get set up and what we look for in contributions.
+
+## Before you start
+
+- **Issues first (for non-trivial work):** open or comment on an [issue](https://github.com/meet447/MeuxCompanion/issues) so maintainers can agree on direction and avoid duplicate effort.
+- **Code of conduct:** everyone participating is expected to follow the [Code of Conduct](CODE_OF_CONDUCT.md).
+
+## Development setup
+
+Prerequisites:
+
+- **Node.js** 18 or newer
+- **Rust** stable (with Cargo), as required by [Tauri 2](https://v2.tauri.app/start/prerequisites/)
+- On **Linux**, install WebKitGTK and related packages (see the [release workflow](.github/workflows/release.yml) for the list used in CI).
+
+Clone and run in development mode:
+
+```bash
+git clone https://github.com/meet447/MeuxCompanion.git
+cd MeuxCompanion
+npm install
+npm run tauri dev
+```
+
+Build a production bundle locally:
+
+```bash
+npm run tauri build
+```
+
+## Pull requests
+
+- **One logical change per PR** when possible (easier to review and revert).
+- **Describe the change** in the PR body: what problem it solves, how you tested it, and any user-visible impact.
+- **Match existing style:** formatting, naming, and patterns used in nearby code.
+- **Keep commits readable:** clear messages; squash fixup commits before merge if asked.
+
+## Areas of the repo
+
+- `src/` — React (Vite) frontend
+- `src-tauri/` — Tauri shell and Rust commands
+- `crates/meux-core/` — shared Rust logic (LLM, memory, state, and related services)
+
+## Questions
+
+Use [GitHub Discussions](https://github.com/meet447/MeuxCompanion/discussions) or an issue if something in this guide is unclear or outdated.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 The MeuxCompanion contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,97 +1,109 @@
 # MeuxCompanion
 
-A local-first AI companion desktop app with Live2D and VRM avatars, layered character writing, persistent memory, and evolving relationship state.
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
 
-> **Desktop Port** — This application has been ported from a web app to a standalone desktop application using **Tauri 2**.
+A **local-first** AI companion **desktop app** with Live2D and VRM avatars, layered character writing, persistent memory, and evolving relationship state.
 
-![MeuxCompanion Demo](assets/demo.png)
+> Built with [**Tauri 2**](https://v2.tauri.app/) (Rust + web frontend). Your chats and memory stay on your machine unless you configure external APIs.
 
-## What It Does
+![MeuxCompanion demo](assets/demo.png)
 
-MeuxCompanion is a native desktop application that lets you talk to an anime-style companion through text or voice. It features a high-performance Rust backend for:
+## Table of contents
 
-- **Layered character identity** — written as `.yaml` and `.md` files
-- **Session history** — local persistence of chats
-- **Local long-term memory** — semantic, episodic, and reflection memories
-- **Persistent relationship state** — trust, affection, mood, and energy
-- **Expression-aware streaming** — parse LLM output for emotion tags in real-time
-- **Parallel TTS generation** — high-speed speech synthesis per sentence
-
-## Quick Start
-
-### Prerequisites
-
-- **Node.js 18+**
-- **Rust (Cargo) 1.75+**
-
-### Install & Run
-
-```bash
-git clone https://github.com/meuxtw/MeuxVtuber.git
-cd MeuxVtuber
-
-# Install frontend dependencies
-npm install
-
-# Run the desktop app in development mode
-npm run tauri dev
-```
+- [Features](#features)
+- [Quick start](#quick-start)
+- [Development](#development)
+- [Releases](#releases)
+- [Contributing](#contributing)
+- [Security](#security)
+- [License](#license)
 
 ## Features
 
-### Companion Core
-- **Layered Characters**: companions are modularly written (`soul.md`, `style.md`, `rules.md`, etc.)
-- **Local Memory**: Semantic and episodic memories stored as local JSONL files.
-- **Relationship State**: Trust and affection evolve over time based on your interactions.
+### Companion core
+
+- **Layered characters** — written as `.yaml` and `.md` files (`soul.md`, `style.md`, `rules.md`, etc.)
+- **Session history** — local persistence of chats
+- **Local long-term memory** — semantic, episodic, and reflection-style memories (local storage)
+- **Relationship state** — trust, affection, mood, and energy evolve over time
+- **Expression-aware streaming** — parses LLM output for emotion tags in real time (`<<expression>>`)
 
 ### Interaction
-- **Streaming Chat**: Real-time text streaming.
-- **Per-sentence Expressions**: Live parsing of `<<expression>>` tags for avatar reaction.
-- **Parallel TTS**: Synthesizes speech segments in parallel for minimal latency.
-- **Voice Input**: Integrated microphone support.
 
-### Avatar System
-- **Live2D**: Support for Cubism models with lip sync and expression mapping.
-- **VRM**: Support for 3D avatars with custom animations.
-- **Mini-Mode**: Toggle a transparent "Mini Widget" that floats on your desktop.
+- **Streaming chat** — real-time text streaming
+- **Parallel TTS** — synthesizes speech segments in parallel for lower latency
+- **Voice input** — microphone capture, VAD, and optional Whisper-based transcription
 
-## Development
+### Avatars
 
-The project is structured as a Tauri monorepo:
+- **Live2D** — Cubism models with lip sync and expression mapping
+- **VRM** — 3D avatars with custom animations
+- **Mini mode** — transparent “mini widget” that can float on your desktop
 
-- `src/`: React frontend (Vite)
-- `src-tauri/`: Tauri Rust core and command handlers
-- `crates/meux-core/`: Shared Rust logic for LLM, TTS, and memory
+## Quick start
+
+### Prerequisites
+
+- **Node.js** 18 or newer
+- **Rust** stable with **Cargo** (see [Tauri prerequisites](https://v2.tauri.app/start/prerequisites/) for OS-specific packages)
+- **Linux:** WebKitGTK and related dev packages (the same set [used in CI](.github/workflows/release.yml) is a good reference)
+
+### Install and run (development)
 
 ```bash
-# Start development server
+git clone https://github.com/meet447/MeuxCompanion.git
+cd MeuxCompanion
+npm install
 npm run tauri dev
 ```
 
-## Providers
+### Production build
 
-### LLM
-Uses the OpenAI SDK protocol against any compatible endpoint (OpenAI, Groq, Ollama, OpenRouter, etc.).
+```bash
+npm run tauri build
+```
 
-### TTS
-Supports multiple providers including:
-- **TikTok TTS**: Local-friendly, no API key required.
-- **ElevenLabs**: High-quality neural voices.
-- **OpenAI TTS**: Native OpenAI voice support.
+## Providers (optional)
 
-## Project Structure
+You choose which remote services to use, if any:
+
+- **LLM** — OpenAI-compatible HTTP APIs (OpenAI, Groq, Ollama, OpenRouter, and similar). Configure endpoints and keys in the app; nothing is sent until you set this up.
+- **TTS** — includes options such as local-friendly TikTok TTS (no key), ElevenLabs, and OpenAI TTS, depending on your configuration.
+
+## Project structure
 
 ```text
 MeuxCompanion/
-├── src/                # React / Vite Frontend
-├── src-tauri/          # Tauri Rust App
-├── crates/             # Shared Rust logic
-│   └── meux-core/      # Core logic (LLM, Memory, State)
-├── characters/         # Local companion profiles
-├── models/             # Live2D and VRM models
-└── data/               # Persistent session and memory data
+├── src/                 # React (Vite) frontend
+├── src-tauri/           # Tauri shell and Rust commands
+├── crates/meux-core/    # Shared Rust logic (LLM, memory, state, …)
+├── characters/          # Local companion profiles
+├── models/              # Live2D and VRM assets
+└── data/                # Local session and memory data (created at runtime)
 ```
+
+## Development
+
+```bash
+npm run tauri dev    # desktop app + hot reload
+npm run dev          # Vite frontend only (without Tauri shell)
+```
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for how we handle issues, pull requests, and code review.
+
+## Releases
+
+Tagged releases are built with [GitHub Actions](.github/workflows/release.yml). Maintainers publish draft GitHub Releases from CI artifacts when ready.
+
+## Contributing
+
+We welcome issues and pull requests. Please read [CONTRIBUTING.md](CONTRIBUTING.md) and [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) before participating.
+
+## Security
+
+If you discover a security vulnerability in **this repository**, please follow [SECURITY.md](SECURITY.md) so we can address it responsibly.
 
 ## License
 
-MIT
+This project is licensed under the [MIT License](LICENSE).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,20 @@
+# Security
+
+## Reporting a vulnerability
+
+Please **do not** open a public GitHub issue for security-sensitive reports.
+
+Instead, use one of these options:
+
+1. **GitHub Security Advisories** (preferred): open a [private security advisory](https://github.com/meet447/MeuxCompanion/security/advisories/new) for this repository.
+2. If you cannot use GitHub: contact the maintainers through a private channel they have published on their profile or project documentation.
+
+Include enough detail to reproduce or understand the issue (steps, affected versions, impact). We will acknowledge receipt as soon as we can and work with you on a coordinated disclosure before any public fix.
+
+## Scope
+
+This project is a **desktop application** (Tauri). Reports about third-party services you configure (LLM or TTS providers, API keys stored locally on your machine) are generally out of scope unless they expose a defect in **this** codebase.
+
+## Supported versions
+
+Security fixes are applied to the default branch (`main`) and released as tagged versions when appropriate. Use the latest release when possible.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The README was helpful for describing the product, but it was not yet aligned with common open-source expectations for a starred community project.

## Changes

- **README**: Fixed the clone URL and folder name (they pointed at a different repo and name). Added badges, a table of contents, clearer prerequisites (including Linux packages via CI reference), optional providers wording, releases note, and links to contributing and security docs.
- **LICENSE**: Added the MIT license text so GitHub can detect the license and downstream users have a single canonical file.
- **CONTRIBUTING.md**: Local setup, PR expectations, and repo layout pointers.
- **CODE_OF_CONDUCT.md**: Contributor Covenant 2.1.
- **SECURITY.md**: Private reporting via GitHub Security Advisories and scope notes for this desktop app.

## Notes for maintainers

If the default branch is still `master`, either merge this into `main` or retarget the PR to `master` before merge. After merge, consider enabling GitHub’s default community health files (issue templates, discussion categories) if not already set.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3f7ade56-caf9-48be-98a7-464745594030"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3f7ade56-caf9-48be-98a7-464745594030"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

