### PR TITLE
🔒 Security fix: Prevent Command Injection in open_application tool

### DIFF
--- a/crates/meux-core/src/tools/desktop.rs
+++ b/crates/meux-core/src/tools/desktop.rs
@@ -11,6 +11,14 @@ use super::Tool;
 // open_application
 // ---------------------------------------------------------------------------
 
+fn is_valid_app_name(name: &str) -> bool {
+    if name.is_empty() || name.starts_with('-') {
+        return false;
+    }
+    // Allow alphanumeric, space, dot, hyphen, underscore
+    name.chars().all(|c| c.is_alphanumeric() || c == ' ' || c == '.' || c == '-' || c == '_')
+}
+
 pub struct OpenApplicationTool;
 
 #[async_trait]
@@ -37,6 +45,10 @@ impl Tool for OpenApplicationTool {
         let name = arguments["name"]
             .as_str()
             .ok_or_else(|| MeuxError::Tool("Missing 'name' argument".to_string()))?;
+
+        if !is_valid_app_name(name) {
+            return Err(MeuxError::Tool(format!("Invalid application name: {}", name)));
+        }
 
         let output = tokio::process::Command::new("open")
             .arg("-a")
@@ -390,4 +402,25 @@ fn extract_vm_stat_value(line: &str) -> Option<u64> {
         return None;
     }
     parts[1].trim().trim_end_matches('.').parse::<u64>().ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_valid_app_name() {
+        assert!(is_valid_app_name("Safari"));
+        assert!(is_valid_app_name("Visual Studio Code"));
+        assert!(is_valid_app_name("iTerm2"));
+        assert!(is_valid_app_name("TextEdit.app"));
+        assert!(is_valid_app_name("App_Name-1.0"));
+
+        assert!(!is_valid_app_name(""));
+        assert!(!is_valid_app_name("-Safari"));
+        assert!(!is_valid_app_name("--args"));
+        assert!(!is_valid_app_name("Not an app; rm -rf /"));
+        assert!(!is_valid_app_name("App|Name"));
+        assert!(!is_valid_app_name("App&Name"));
+    }
 }


### PR DESCRIPTION
🎯 **What:**
Fixes a potential Command Injection vulnerability in the `open_application` tool (`crates/meux-core/src/tools/desktop.rs`).

⚠️ **Risk:**
The `name` argument was previously passed directly to `tokio::process::Command::new("open").arg("-a").arg(name)` without adequate validation. While `Command::arg` escapes typical shell metacharacters, it was still possible for an attacker to craft a malicious application name (e.g., one starting with `-`) to inject flags or unintended arguments into the `open` command. This could lead to unauthorized actions or unintended behavior depending on how `open -a` parses subsequent arguments.

🛡️ **Solution:**
Introduced the `is_valid_app_name` function which enforces strict validation on the application name.
- Fails immediately if the name starts with a hyphen (`-`), blocking flag injection.
- Restricts the allowed characters strictly to alphanumeric characters, spaces, dots, hyphens, and underscores.
- If an invalid name is detected, the tool now safely returns a `MeuxError::Tool` error.
- Also added unit tests in `crates/meux-core/src/tools/desktop.rs` to verify the logic.

---
*PR created automatically by Jules for task [15224668577835001709](https://jules.google.com/task/15224668577835001709) started by @meet447*