### PR TITLE
🧪 [testing improvement description] Add tests for desktop organization tool

### DIFF
--- a/crates/meux-core/src/tools/desktop.rs
+++ b/crates/meux-core/src/tools/desktop.rs
@@ -142,11 +142,17 @@ impl Tool for OrganizeDesktopTool {
         let desktop = dirs::desktop_dir()
             .ok_or_else(|| MeuxError::Tool("Could not find Desktop directory".to_string()))?;
 
+        Self::organize_directory(&desktop)
+    }
+}
+
+impl OrganizeDesktopTool {
+    pub fn organize_directory(desktop: &std::path::Path) -> Result<ToolResult> {
         let category_map = build_extension_map();
         let mut moved: Vec<String> = Vec::new();
         let mut errors: Vec<String> = Vec::new();
 
-        let entries = std::fs::read_dir(&desktop).map_err(|e| MeuxError::Tool(e.to_string()))?;
+        let entries = std::fs::read_dir(desktop).map_err(|e| MeuxError::Tool(e.to_string()))?;
 
         for entry in entries {
             let entry = match entry {
@@ -390,4 +396,52 @@ fn extract_vm_stat_value(line: &str) -> Option<u64> {
         return None;
     }
     parts[1].trim().trim_end_matches('.').parse::<u64>().ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+    use std::fs::{self, File};
+
+    #[test]
+    fn test_organize_directory() {
+        let dir = tempdir().unwrap();
+        let path = dir.path();
+
+        // Create dummy files matching expected categories
+        File::create(path.join("test.png")).unwrap();    // Images
+        File::create(path.join("doc.pdf")).unwrap();     // Documents
+        File::create(path.join("video.mp4")).unwrap();   // Videos
+        File::create(path.join("song.mp3")).unwrap();    // Music
+        File::create(path.join("archive.zip")).unwrap(); // Archives
+        File::create(path.join("script.rs")).unwrap();   // Code
+        File::create(path.join("unknown.xyz")).unwrap(); // Other
+
+        // Edge cases
+        File::create(path.join(".hidden.txt")).unwrap(); // Hidden file
+        fs::create_dir(path.join("subfolder")).unwrap(); // Sub-directory
+
+        // Organize the temporary directory
+        let result = OrganizeDesktopTool::organize_directory(path).unwrap();
+        assert!(result.success);
+
+        // Verify categories
+        assert!(path.join("Images/test.png").exists());
+        assert!(path.join("Documents/doc.pdf").exists());
+        assert!(path.join("Videos/video.mp4").exists());
+        assert!(path.join("Music/song.mp3").exists());
+        assert!(path.join("Archives/archive.zip").exists());
+        assert!(path.join("Code/script.rs").exists());
+        assert!(path.join("Other/unknown.xyz").exists());
+
+        // Verify edge cases are ignored and still in the root of temp dir
+        assert!(path.join(".hidden.txt").exists());
+        assert!(path.join("subfolder").is_dir());
+
+        // Verify original files are gone from the root of temp dir
+        assert!(!path.join("test.png").exists());
+        assert!(!path.join("doc.pdf").exists());
+        assert!(!path.join("video.mp4").exists());
+    }
 }


### PR DESCRIPTION
🎯 **What:** The testing gap for `OrganizeDesktopTool` was addressed by refactoring the core logic into a testable static method (`organize_directory`) that accepts a path parameter, rather than hardcoding the real Desktop path.
📊 **Coverage:** The new tests cover:
- Happy paths: Standard files mapped to Image, Document, Video, Music, Archive, Code, and Other categories.
- Edge cases: Hidden files (`.hidden.txt`) and sub-directories are correctly ignored.
✨ **Result:** Increased test coverage and ensured deterministic testing without affecting the user's actual Desktop directory.

---
*PR created automatically by Jules for task [16563396884465589200](https://jules.google.com/task/16563396884465589200) started by @meet447*