### PR TITLE
🧪 Add tests for clipboard read/write tools

### DIFF
--- a/crates/meux-core/src/tools/clipboard.rs
+++ b/crates/meux-core/src/tools/clipboard.rs
@@ -73,6 +73,52 @@ impl Tool for ClipboardReadTool {
     }
 }
 
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[tokio::test]
+    async fn test_clipboard_read_definition() {
+        let tool = ClipboardReadTool;
+        let def = tool.definition();
+
+        assert_eq!(def.name, "clipboard_read");
+        assert_eq!(def.permission_level, PermissionLevel::Safe);
+        assert_eq!(def.parameters["type"], "object");
+        assert!(def.parameters["required"].as_array().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_clipboard_write_definition() {
+        let tool = ClipboardWriteTool;
+        let def = tool.definition();
+
+        assert_eq!(def.name, "clipboard_write");
+        assert_eq!(def.permission_level, PermissionLevel::Cautious);
+        assert_eq!(def.parameters["type"], "object");
+
+        let required = def.parameters["required"].as_array().unwrap();
+        assert_eq!(required.len(), 1);
+        assert_eq!(required[0].as_str().unwrap(), "content");
+    }
+
+    #[tokio::test]
+    async fn test_clipboard_write_missing_content() {
+        let tool = ClipboardWriteTool;
+        let args = json!({});
+
+        let result = tool.execute(args).await;
+        assert!(result.is_err());
+        if let Err(MeuxError::Tool(msg)) = result {
+            assert_eq!(msg, "Missing 'content' argument");
+        } else {
+            panic!("Expected Tool error with missing content message");
+        }
+    }
+}
+
 // ---------------------------------------------------------------------------
 // clipboard_write
 // ---------------------------------------------------------------------------

--- a/crates/meux-core/src/tools/mod.rs
+++ b/crates/meux-core/src/tools/mod.rs
@@ -1,4 +1,5 @@
 pub mod types;
+pub mod clipboard;
 pub mod desktop;
 pub mod file_ops;
 pub mod shell;


### PR DESCRIPTION
🎯 **What:** Added tests for the `ClipboardReadTool` and `ClipboardWriteTool` definitions, and error handling for missing parameters in `ClipboardWriteTool`. This improves code reliability without introducing flaky system-level interactions.
📊 **Coverage:** Now validates tool schemas, names, permission levels, and bad argument handling.
✨ **Result:** Increased test coverage for OS-specific clipboard tools in a robust, deterministic way.

---
*PR created automatically by Jules for task [14025631362598310178](https://jules.google.com/task/14025631362598310178) started by @meet447*