### PR TITLE
🧪 Add unit tests for shell command execution tool

### DIFF
--- a/crates/meux-core/src/tools/mod.rs
+++ b/crates/meux-core/src/tools/mod.rs
@@ -50,7 +50,7 @@ impl ToolRegistry {
         registry.register(Box::new(file_ops::MoveFileTool));
         registry.register(Box::new(file_ops::DeleteFileTool));
         // Shell
-        registry.register(Box::new(shell::RunCommandTool));
+        registry.register(Box::new(shell::RunCommandTool::new()));
         // Desktop
         registry.register(Box::new(desktop::OpenApplicationTool));
         registry.register(Box::new(desktop::OpenUrlTool));

--- a/crates/meux-core/src/tools/shell.rs
+++ b/crates/meux-core/src/tools/shell.rs
@@ -8,7 +8,60 @@ use crate::error::{MeuxError, Result};
 use super::types::*;
 use super::Tool;
 
-pub struct RunCommandTool;
+pub struct CommandOutput {
+    pub stdout: Vec<u8>,
+    pub stderr: Vec<u8>,
+    pub status_code: Option<i32>,
+    pub success: bool,
+}
+
+#[async_trait]
+pub trait CommandRunner: Send + Sync {
+    async fn run(&self, command: &str) -> Result<CommandOutput>;
+}
+
+pub struct DefaultCommandRunner;
+
+#[async_trait]
+impl CommandRunner for DefaultCommandRunner {
+    async fn run(&self, command: &str) -> Result<CommandOutput> {
+        let output = tokio::time::timeout(
+            std::time::Duration::from_secs(30),
+            Command::new("sh")
+                .arg("-c")
+                .arg(command)
+                .stdout(Stdio::piped())
+                .stderr(Stdio::piped())
+                .output(),
+        )
+        .await
+        .map_err(|_| MeuxError::Tool("Command timed out after 30 seconds".to_string()))?
+        .map_err(|e| MeuxError::Tool(e.to_string()))?;
+
+        Ok(CommandOutput {
+            stdout: output.stdout,
+            stderr: output.stderr,
+            status_code: output.status.code(),
+            success: output.status.success(),
+        })
+    }
+}
+
+pub struct RunCommandTool {
+    runner: Box<dyn CommandRunner>,
+}
+
+impl RunCommandTool {
+    pub fn new() -> Self {
+        Self {
+            runner: Box::new(DefaultCommandRunner),
+        }
+    }
+
+    pub fn with_runner(runner: Box<dyn CommandRunner>) -> Self {
+        Self { runner }
+    }
+}
 
 #[async_trait]
 impl Tool for RunCommandTool {
@@ -37,22 +90,11 @@ impl Tool for RunCommandTool {
             .as_str()
             .ok_or_else(|| MeuxError::Tool("Missing 'command' argument".to_string()))?;
 
-        let output = tokio::time::timeout(
-            std::time::Duration::from_secs(30),
-            Command::new("sh")
-                .arg("-c")
-                .arg(command)
-                .stdout(Stdio::piped())
-                .stderr(Stdio::piped())
-                .output(),
-        )
-        .await
-        .map_err(|_| MeuxError::Tool("Command timed out after 30 seconds".to_string()))?
-        .map_err(|e| MeuxError::Tool(e.to_string()))?;
+        let output = self.runner.run(command).await?;
 
         let stdout = String::from_utf8_lossy(&output.stdout);
         let stderr = String::from_utf8_lossy(&output.stderr);
-        let exit_code = output.status.code().unwrap_or(-1);
+        let exit_code = output.status_code.unwrap_or(-1);
 
         let content = if stderr.is_empty() {
             format!("Exit code: {}\n\n{}", exit_code, stdout)
@@ -76,7 +118,127 @@ impl Tool for RunCommandTool {
         Ok(ToolResult {
             tool_call_id: String::new(),
             content,
-            success: output.status.success(),
+            success: output.success,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+
+
+    struct MockCommandRunner {
+        result: Result<CommandOutput>,
+        // We can track the command that was run if we want, but for these tests
+        // we just return the mocked result.
+    }
+
+    impl MockCommandRunner {
+        fn new_success(stdout: &str, stderr: &str, exit_code: i32) -> Self {
+            Self {
+                result: Ok(CommandOutput {
+                    stdout: stdout.as_bytes().to_vec(),
+                    stderr: stderr.as_bytes().to_vec(),
+                    status_code: Some(exit_code),
+                    success: exit_code == 0,
+                }),
+            }
+        }
+
+        fn new_error(error_msg: &str) -> Self {
+            Self {
+                result: Err(MeuxError::Tool(error_msg.to_string())),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl CommandRunner for MockCommandRunner {
+        async fn run(&self, _command: &str) -> Result<CommandOutput> {
+            match &self.result {
+                Ok(output) => Ok(CommandOutput {
+                    stdout: output.stdout.clone(),
+                    stderr: output.stderr.clone(),
+                    status_code: output.status_code,
+                    success: output.success,
+                }),
+                Err(e) => Err(MeuxError::Tool(e.to_string())),
+            }
+        }
+    }
+
+    #[test]
+    fn test_definition() {
+        let tool = RunCommandTool::new();
+        let def = tool.definition();
+        assert_eq!(def.name, "run_command");
+        assert_eq!(def.permission_level, PermissionLevel::Dangerous);
+        assert!(def.parameters["properties"].get("command").is_some());
+    }
+
+    #[tokio::test]
+    async fn test_success_path() {
+        let mock_runner = MockCommandRunner::new_success("test output", "", 0);
+        let tool = RunCommandTool::with_runner(Box::new(mock_runner));
+
+        let result = tool.execute(json!({"command": "echo 'test output'"})).await.unwrap();
+
+        assert!(result.success);
+        assert_eq!(result.content, "Exit code: 0\n\ntest output");
+    }
+
+    #[tokio::test]
+    async fn test_missing_command() {
+        let tool = RunCommandTool::new();
+        let result = tool.execute(json!({})).await;
+
+        assert!(result.is_err());
+        if let Err(MeuxError::Tool(msg)) = result {
+            assert_eq!(msg, "Missing 'command' argument");
+        } else {
+            panic!("Expected MeuxError::Tool");
+        }
+    }
+
+    #[tokio::test]
+    async fn test_stderr_output() {
+        let mock_runner = MockCommandRunner::new_success("out", "err", 1);
+        let tool = RunCommandTool::with_runner(Box::new(mock_runner));
+
+        let result = tool.execute(json!({"command": "some_cmd"})).await.unwrap();
+
+        assert!(!result.success);
+        assert_eq!(result.content, "Exit code: 1\n\nStdout:\nout\n\nStderr:\nerr");
+    }
+
+    #[tokio::test]
+    async fn test_large_output_truncation() {
+        let large_stdout = String::from_utf8(vec![b'A'; 60000]).unwrap();
+        let mock_runner = MockCommandRunner::new_success(&large_stdout, "", 0);
+        let tool = RunCommandTool::with_runner(Box::new(mock_runner));
+
+        let result = tool.execute(json!({"command": "large_output_cmd"})).await.unwrap();
+
+        assert!(result.success);
+        assert!(result.content.ends_with("\n\n[Output truncated — showing first 50KB]"));
+        assert_eq!(result.content.len(), 50000 + "\n\n[Output truncated — showing first 50KB]".len());
+    }
+
+    #[tokio::test]
+    async fn test_command_timeout_error() {
+        let mock_runner = MockCommandRunner::new_error("Command timed out after 30 seconds");
+        let tool = RunCommandTool::with_runner(Box::new(mock_runner));
+
+        let result = tool.execute(json!({"command": "sleep 100"})).await;
+
+        assert!(result.is_err());
+        if let Err(MeuxError::Tool(msg)) = result {
+            assert_eq!(msg, "Tool error: Command timed out after 30 seconds");
+        } else {
+            panic!("Expected MeuxError::Tool");
+        }
     }
 }


### PR DESCRIPTION
🎯 **What:** Added tests to address the testing gap for the `RunCommandTool` shell command execution tool. The tool previously invoked actual system commands using `tokio::process::Command`, which made unit testing difficult and environment-dependent.
  
📊 **Coverage:** 
- Successfully refactored `RunCommandTool` to decouple command execution logic by introducing a `CommandRunner` trait.
- Created `MockCommandRunner` for tests, allowing safe and fast testing without running OS commands.
- Covered test scenarios include:
  - Validating tool definitions.
  - Successful command execution with standard output.
  - Commands with missing arguments.
  - Proper capturing and formatting of standard error streams.
  - Logic that truncates outputs larger than 50KB.
  - Proper handling of command execution timeouts/errors.

✨ **Result:** Improved test coverage and reliability for `meux-core`. Allows confident refactoring without the risk of breaking shell command execution features.

---
*PR created automatically by Jules for task [7642294843529050740](https://jules.google.com/task/7642294843529050740) started by @meet447*