### PR TITLE
🔒 Fix path traversal vulnerability in DeleteFileTool

### DIFF
--- a/crates/meux-core/src/tools/file_ops.rs
+++ b/crates/meux-core/src/tools/file_ops.rs
@@ -526,7 +526,17 @@ impl Tool for MoveFileTool {
 // delete_file
 // ---------------------------------------------------------------------------
 
-pub struct DeleteFileTool;
+use std::path::PathBuf;
+
+pub struct DeleteFileTool {
+    base_dir: PathBuf,
+}
+
+impl DeleteFileTool {
+    pub fn new(base_dir: PathBuf) -> Self {
+        Self { base_dir }
+    }
+}
 
 #[async_trait]
 impl Tool for DeleteFileTool {
@@ -560,6 +570,24 @@ impl Tool for DeleteFileTool {
             return Ok(ToolResult {
                 tool_call_id: String::new(),
                 content: format!("Path not found: {}", path.display()),
+                success: false,
+            });
+        }
+
+        // Security fix: Path Traversal Prevention
+        // Canonicalize both the requested path and the base directory to resolve any ".." or symlinks.
+        let canonical_path = path.canonicalize().map_err(|e| MeuxError::Tool(format!("Failed to canonicalize path: {}", e)))?;
+
+        let canonical_base = if self.base_dir.exists() {
+            self.base_dir.canonicalize().map_err(|e| MeuxError::Tool(format!("Failed to canonicalize base_dir: {}", e)))?
+        } else {
+            self.base_dir.clone() // Fallback if base_dir doesn't exist (though it should)
+        };
+
+        if !canonical_path.starts_with(&canonical_base) {
+            return Ok(ToolResult {
+                tool_call_id: String::new(),
+                content: format!("Access denied: Path {} is outside the allowed directory.", path.display()),
                 success: false,
             });
         }

--- a/crates/meux-core/src/tools/mod.rs
+++ b/crates/meux-core/src/tools/mod.rs
@@ -38,7 +38,7 @@ impl ToolRegistry {
     }
 
     /// Create a registry with all built-in tools registered.
-    pub fn with_defaults() -> Self {
+    pub fn with_defaults(base_dir: std::path::PathBuf) -> Self {
         let mut registry = Self::new();
         // File tools
         registry.register(Box::new(file_ops::ReadFileTool));
@@ -48,7 +48,7 @@ impl ToolRegistry {
         registry.register(Box::new(file_ops::FindFilesTool));
         registry.register(Box::new(file_ops::EditFileTool));
         registry.register(Box::new(file_ops::MoveFileTool));
-        registry.register(Box::new(file_ops::DeleteFileTool));
+        registry.register(Box::new(file_ops::DeleteFileTool::new(base_dir)));
         // Shell
         registry.register(Box::new(shell::RunCommandTool));
         // Desktop

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -106,7 +106,7 @@ pub fn run() {
                 expressions: ExpressionManager::new(&data_dir),
                 llm: OpenAiCompatClient::new(),
                 whisper_ctx,
-                tool_registry: ToolRegistry::with_defaults(),
+                tool_registry: ToolRegistry::with_defaults(data_dir.clone()),
                 pending_confirmations: DashMap::new(),
                 chat_cancel: std::sync::Mutex::new(None),
             };


### PR DESCRIPTION
🎯 **What:** The `DeleteFileTool` had an arbitrary file deletion vulnerability due to unvalidated path traversal. It allowed deletion of files outside the intended application data directory.
⚠️ **Risk:** A malicious input or compromised character definition could issue a command to delete critical system files or user documents outside of the application's sandbox (e.g., using paths like `../../../../etc/passwd` or `~/.ssh/id_rsa`).
🛡️ **Solution:** The fix introduces a `base_dir` requirement for `DeleteFileTool`. Before deleting any file or directory, the tool canonicalizes both the requested path and the `base_dir`, then explicitly verifies that the canonical requested path starts with the canonical `base_dir`. This strictly enforces that deletions can only occur within the allowed boundary.

---
*PR created automatically by Jules for task [2580329181882148916](https://jules.google.com/task/2580329181882148916) started by @meet447*