### PR TITLE
Add CI workflow for frontend and Rust/Tauri builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,84 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  frontend:
+    name: Frontend (TypeScript, build, tests)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Typecheck and production build
+        run: npm run build
+
+      - name: Unit tests (Vitest)
+        run: npm test
+
+  rust:
+    name: Rust (fmt, clippy, tests, Tauri build)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            build-essential \
+            cmake \
+            pkg-config \
+            libssl-dev \
+            libclang-dev \
+            clang \
+            libwebkit2gtk-4.1-dev \
+            libappindicator3-dev \
+            librsvg2-dev \
+            patchelf
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+          cache: npm
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - uses: swatinem/rust-cache@v2
+        with:
+          workspaces: ". -> target"
+
+      - name: Install frontend dependencies (Tauri build)
+        run: npm ci
+
+      - name: cargo fmt
+        run: cargo fmt --all -- --check
+
+      - name: cargo clippy
+        run: cargo clippy --workspace --all-targets -- -D warnings
+
+      - name: cargo test
+        run: cargo test --workspace
+
+      - name: Tauri build (smoke)
+        run: npm run tauri build

--- a/crates/meux-core/src/character/mod.rs
+++ b/crates/meux-core/src/character/mod.rs
@@ -102,13 +102,13 @@ impl CharacterLoader {
             .ok_or_else(|| MeuxError::CharacterNotFound(character_id.to_string()))?;
 
         let (mtime_path, source_type_tag) = match &source {
-            CharacterSource::Directory { path, .. } => {
-                (path.join("character.yaml"), "directory")
-            }
+            CharacterSource::Directory { path, .. } => (path.join("character.yaml"), "directory"),
             CharacterSource::Markdown { path, .. } => (path.clone(), "markdown"),
         };
 
-        let mtime = fs::metadata(&mtime_path)?.modified().unwrap_or(SystemTime::UNIX_EPOCH);
+        let mtime = fs::metadata(&mtime_path)?
+            .modified()
+            .unwrap_or(SystemTime::UNIX_EPOCH);
 
         // Check cache
         {
@@ -210,19 +210,11 @@ impl CharacterLoader {
             let path = entry.path();
             if path.is_dir() {
                 if path.join("character.yaml").exists() {
-                    let id = path
-                        .file_name()
-                        .unwrap()
-                        .to_string_lossy()
-                        .to_string();
+                    let id = path.file_name().unwrap().to_string_lossy().to_string();
                     sources.push(CharacterSource::Directory { id, path });
                 }
             } else if path.extension().map(|e| e == "md").unwrap_or(false) {
-                let id = path
-                    .file_stem()
-                    .unwrap()
-                    .to_string_lossy()
-                    .to_string();
+                let id = path.file_stem().unwrap().to_string_lossy().to_string();
                 sources.push(CharacterSource::Markdown { id, path });
             }
         }
@@ -318,7 +310,8 @@ fn build_rules_section(input: &CharacterBlueprintInput<'_>) -> String {
 
 fn build_context_section(input: &CharacterBlueprintInput<'_>) -> String {
     let user_about = if input.user_about.trim().is_empty() {
-        "No personal notes were written yet, so learn the user's rhythms through conversation.".to_string()
+        "No personal notes were written yet, so learn the user's rhythms through conversation."
+            .to_string()
     } else {
         input.user_about.trim().to_string()
     };
@@ -374,7 +367,10 @@ fn load_from_directory(id: &str, dir: &Path) -> Result<Character> {
 
     let read_section = |filename: &str| -> String {
         let p = dir.join(filename);
-        fs::read_to_string(&p).unwrap_or_default().trim().to_string()
+        fs::read_to_string(&p)
+            .unwrap_or_default()
+            .trim()
+            .to_string()
     };
 
     let sections = PromptSections {
@@ -458,11 +454,7 @@ pub fn slugify(value: &str) -> String {
 
 /// Build a full system prompt from character sections and expression list.
 pub fn build_system_prompt(character: &Character, expressions: &[&str]) -> String {
-    build_system_prompt_from_sections(
-        &character.name,
-        &character.prompt_sections,
-        expressions,
-    )
+    build_system_prompt_from_sections(&character.name, &character.prompt_sections, expressions)
 }
 
 fn build_system_prompt_from_sections(
@@ -619,7 +611,12 @@ pub fn get_model_expressions(data_dir: &Path, model_id: &str) -> Result<Vec<Stri
 
     // Try VRM
     let vrm_dir = models_dir.join("vrm").join(model_id);
-    if vrm_dir.exists() || models_dir.join("vrm").join(format!("{}.vrm", model_id)).exists() {
+    if vrm_dir.exists()
+        || models_dir
+            .join("vrm")
+            .join(format!("{}.vrm", model_id))
+            .exists()
+    {
         // VRM models have standard blend shape expressions
         return Ok(vec![
             "happy".to_string(),

--- a/crates/meux-core/src/config/mod.rs
+++ b/crates/meux-core/src/config/mod.rs
@@ -230,10 +230,7 @@ impl ConfigManager {
         for (name, preset) in LLM_PRESETS {
             let configured = if let Some(provider_cfg) = config.llm_providers.get(*name) {
                 if preset.needs_key {
-                    provider_cfg
-                        .api_key
-                        .as_ref()
-                        .is_some_and(|k| !k.is_empty())
+                    provider_cfg.api_key.as_ref().is_some_and(|k| !k.is_empty())
                 } else {
                     true
                 }
@@ -249,10 +246,7 @@ impl ConfigManager {
         for (name, preset) in TTS_PRESETS {
             let configured = if let Some(provider_cfg) = config.tts_providers.get(*name) {
                 if preset.needs_key {
-                    provider_cfg
-                        .api_key
-                        .as_ref()
-                        .is_some_and(|k| !k.is_empty())
+                    provider_cfg.api_key.as_ref().is_some_and(|k| !k.is_empty())
                 } else {
                     true
                 }

--- a/crates/meux-core/src/context/mod.rs
+++ b/crates/meux-core/src/context/mod.rs
@@ -16,7 +16,9 @@ fn message_tokens(msg: &ChatMessage) -> usize {
         .map(|calls| {
             calls
                 .iter()
-                .map(|tc| estimate_tokens(&tc.function.name) + estimate_tokens(&tc.function.arguments))
+                .map(|tc| {
+                    estimate_tokens(&tc.function.name) + estimate_tokens(&tc.function.arguments)
+                })
                 .sum::<usize>()
         })
         .unwrap_or(0);
@@ -57,10 +59,8 @@ pub fn compress_stale_tool_results(messages: &mut Vec<ChatMessage>, recent_tool_
                 format!("{} chars", content_len)
             };
             let summary = format!("[tool result: {} returned {}]", tool_name, size_label);
-            messages[idx] = ChatMessage::tool_result(
-                msg.tool_call_id.as_deref().unwrap_or(""),
-                &summary,
-            );
+            messages[idx] =
+                ChatMessage::tool_result(msg.tool_call_id.as_deref().unwrap_or(""), &summary);
         }
     }
 }
@@ -108,21 +108,12 @@ pub fn apply_token_budget(messages: &mut Vec<ChatMessage>, max_tokens: usize) {
     }
 
     // Separate: system messages (front), droppable middle, last user message
-    let system_count = messages
-        .iter()
-        .take_while(|m| m.role == "system")
-        .count();
+    let system_count = messages.iter().take_while(|m| m.role == "system").count();
 
-    let has_user_at_end = messages
-        .last()
-        .map(|m| m.role == "user")
-        .unwrap_or(false);
+    let has_user_at_end = messages.last().map(|m| m.role == "user").unwrap_or(false);
 
     // Calculate fixed token cost (system + last user message)
-    let system_tokens: usize = messages[..system_count]
-        .iter()
-        .map(message_tokens)
-        .sum();
+    let system_tokens: usize = messages[..system_count].iter().map(message_tokens).sum();
 
     let last_msg_tokens = if has_user_at_end {
         message_tokens(messages.last().unwrap())

--- a/crates/meux-core/src/expressions/mod.rs
+++ b/crates/meux-core/src/expressions/mod.rs
@@ -77,11 +77,7 @@ impl ExpressionManager {
 
     /// Save an expression mapping for a model. Creates the mappings directory if needed,
     /// writes pretty JSON, and updates the cache.
-    pub fn save_mapping(
-        &self,
-        model_id: &str,
-        mapping: HashMap<String, String>,
-    ) -> Result<()> {
+    pub fn save_mapping(&self, model_id: &str, mapping: HashMap<String, String>) -> Result<()> {
         std::fs::create_dir_all(&self.mappings_dir)?;
 
         let path = self.mappings_dir.join(format!("{}.json", model_id));
@@ -164,11 +160,7 @@ mod tests {
 
     #[test]
     fn test_validate_expression() {
-        let available = vec![
-            "Happy".to_string(),
-            "Sad".to_string(),
-            "Angry".to_string(),
-        ];
+        let available = vec!["Happy".to_string(), "Sad".to_string(), "Angry".to_string()];
 
         // Case-insensitive match works.
         assert_eq!(

--- a/crates/meux-core/src/lib.rs
+++ b/crates/meux-core/src/lib.rs
@@ -6,8 +6,8 @@ pub mod expressions;
 pub mod llm;
 pub mod memory;
 pub mod prompt;
-pub mod session;
 pub mod retry;
+pub mod session;
 pub mod tools;
 pub mod tts;
 

--- a/crates/meux-core/src/llm/openai_compat.rs
+++ b/crates/meux-core/src/llm/openai_compat.rs
@@ -248,12 +248,9 @@ impl OpenAiCompatClient {
         messages: Vec<ChatMessage>,
         config: &LlmStreamConfig,
     ) -> Result<String> {
-        crate::retry::retry_with_backoff(
-            5,
-            500,
-            crate::retry::is_retryable_llm_error,
-            || self.chat_once(messages.clone(), config),
-        )
+        crate::retry::retry_with_backoff(5, 500, crate::retry::is_retryable_llm_error, || {
+            self.chat_once(messages.clone(), config)
+        })
         .await
     }
 
@@ -287,8 +284,7 @@ impl OpenAiCompatClient {
             return Err(MeuxError::Llm(format!("HTTP {}: {}", status, text)));
         }
 
-        let completion: ChatCompletionResponse =
-            response.json().await.map_err(MeuxError::Http)?;
+        let completion: ChatCompletionResponse = response.json().await.map_err(MeuxError::Http)?;
 
         completion
             .choices

--- a/crates/meux-core/src/llm/types.rs
+++ b/crates/meux-core/src/llm/types.rs
@@ -122,9 +122,7 @@ pub enum StreamEvent {
         arguments: String,
     },
     /// Stream finished. finish_reason is "stop" or "tool_calls".
-    Done {
-        finish_reason: String,
-    },
+    Done { finish_reason: String },
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/meux-core/src/memory/extractor.rs
+++ b/crates/meux-core/src/memory/extractor.rs
@@ -11,18 +11,16 @@ pub struct ExtractedMemory {
 
 /// Common English stopwords filtered during tokenisation.
 const STOPWORDS: &[&str] = &[
-    "a", "an", "the", "is", "am", "are", "was", "were", "be", "been", "being",
-    "have", "has", "had", "do", "does", "did", "will", "would", "could", "should",
-    "may", "might", "shall", "can", "need", "dare", "ought", "used", "to", "of",
-    "in", "for", "on", "with", "at", "by", "from", "as", "into", "through",
-    "during", "before", "after", "above", "below", "between", "out", "off", "over",
-    "under", "again", "further", "then", "once", "here", "there", "when", "where",
-    "why", "how", "all", "each", "every", "both", "few", "more", "most", "other",
-    "some", "such", "no", "nor", "not", "only", "own", "same", "so", "than",
-    "too", "very", "just", "because", "but", "and", "or", "if", "while", "about",
-    "up", "it", "its", "i", "me", "my", "myself", "we", "our", "you", "your",
-    "he", "him", "his", "she", "her", "they", "them", "their", "what", "which",
-    "who", "this", "that", "these", "those",
+    "a", "an", "the", "is", "am", "are", "was", "were", "be", "been", "being", "have", "has",
+    "had", "do", "does", "did", "will", "would", "could", "should", "may", "might", "shall", "can",
+    "need", "dare", "ought", "used", "to", "of", "in", "for", "on", "with", "at", "by", "from",
+    "as", "into", "through", "during", "before", "after", "above", "below", "between", "out",
+    "off", "over", "under", "again", "further", "then", "once", "here", "there", "when", "where",
+    "why", "how", "all", "each", "every", "both", "few", "more", "most", "other", "some", "such",
+    "no", "nor", "not", "only", "own", "same", "so", "than", "too", "very", "just", "because",
+    "but", "and", "or", "if", "while", "about", "up", "it", "its", "i", "me", "my", "myself", "we",
+    "our", "you", "your", "he", "him", "his", "she", "her", "they", "them", "their", "what",
+    "which", "who", "this", "that", "these", "those",
 ];
 
 /// Extract candidate memories from a user message using heuristic patterns.
@@ -230,7 +228,9 @@ mod tests {
     fn test_extract_preference() {
         let mems = extract_memories("I like dark themes. I love Rust programming.");
         assert_eq!(mems.len(), 2);
-        assert!(mems.iter().all(|m| m.tags.contains(&"preferences".to_string())));
+        assert!(mems
+            .iter()
+            .all(|m| m.tags.contains(&"preferences".to_string())));
     }
 
     #[test]

--- a/crates/meux-core/src/memory/mod.rs
+++ b/crates/meux-core/src/memory/mod.rs
@@ -25,7 +25,9 @@ pub fn remember_exchange(
     for candidate in &extracted {
         // Deduplicate: skip if an existing memory has the same normalised summary
         let normalised = candidate.summary.to_lowercase();
-        let is_duplicate = existing.iter().any(|m| m.summary.to_lowercase() == normalised);
+        let is_duplicate = existing
+            .iter()
+            .any(|m| m.summary.to_lowercase() == normalised);
         if is_duplicate {
             continue;
         }

--- a/crates/meux-core/src/memory/retriever.rs
+++ b/crates/meux-core/src/memory/retriever.rs
@@ -46,8 +46,7 @@ pub fn retrieve_relevant(query: &str, memories: &[Memory], limit: usize) -> Vec<
             let age_days = (now - mem.ts).num_seconds().max(0) as f64 / 86400.0;
             let recency_bonus = (0.3 - (age_days / 365.0).min(0.3)).max(0.0);
 
-            let score =
-                token_overlap * 1.6 + tag_overlap * 1.2 + mem.importance + recency_bonus;
+            let score = token_overlap * 1.6 + tag_overlap * 1.2 + mem.importance + recency_bonus;
 
             (score, mem)
         })
@@ -91,8 +90,18 @@ mod tests {
     #[test]
     fn test_retrieve_relevant() {
         let memories = vec![
-            make_memory("User likes Rust programming", "semantic", 0.8, vec!["preferences"]),
-            make_memory("User deployed the API server", "episodic", 0.68, vec!["project_context"]),
+            make_memory(
+                "User likes Rust programming",
+                "semantic",
+                0.8,
+                vec!["preferences"],
+            ),
+            make_memory(
+                "User deployed the API server",
+                "episodic",
+                0.68,
+                vec!["project_context"],
+            ),
             make_memory("User's name is Alice", "semantic", 1.0, vec!["identity"]),
         ];
 

--- a/crates/meux-core/src/memory/store.rs
+++ b/crates/meux-core/src/memory/store.rs
@@ -44,7 +44,10 @@ impl MemoryStore {
 
     /// Build the directory path for a specific character + user pair.
     fn store_path(&self, character_id: &str, user_id: &str) -> PathBuf {
-        self.data_dir.join(character_id).join(user_id).join("memory")
+        self.data_dir
+            .join(character_id)
+            .join(user_id)
+            .join("memory")
     }
 
     /// Ensure the on-disk directory and empty JSONL files exist.
@@ -103,9 +106,10 @@ impl MemoryStore {
             metadata: serde_json::Value::Object(serde_json::Map::new()),
         };
 
-        let _guard = self._lock.write().map_err(|e| {
-            MeuxError::Memory(format!("Lock poisoned: {e}"))
-        })?;
+        let _guard = self
+            ._lock
+            .write()
+            .map_err(|e| MeuxError::Memory(format!("Lock poisoned: {e}")))?;
 
         let dir = self.store_path(character_id, user_id);
         let path = dir.join(Self::filename_for(memory_type));
@@ -134,9 +138,10 @@ impl MemoryStore {
             return Ok(vec![]);
         }
 
-        let _guard = self._lock.read().map_err(|e| {
-            MeuxError::Memory(format!("Lock poisoned: {e}"))
-        })?;
+        let _guard = self
+            ._lock
+            .read()
+            .map_err(|e| MeuxError::Memory(format!("Lock poisoned: {e}")))?;
 
         let types_to_read: Vec<&str> = match memory_type {
             Some(mt) => vec![mt],
@@ -184,9 +189,10 @@ impl MemoryStore {
             return Ok(());
         }
 
-        let _guard = self._lock.write().map_err(|e| {
-            MeuxError::Memory(format!("Lock poisoned: {e}"))
-        })?;
+        let _guard = self
+            ._lock
+            .write()
+            .map_err(|e| MeuxError::Memory(format!("Lock poisoned: {e}")))?;
 
         let types_to_clear: Vec<&str> = match memory_type {
             Some(mt) => vec![mt],
@@ -214,13 +220,34 @@ mod tests {
         let store = MemoryStore::new(tmp.path().to_path_buf());
 
         store
-            .append("char1", "user1", "semantic", "User likes Rust", 0.9, vec!["preferences".into()])
+            .append(
+                "char1",
+                "user1",
+                "semantic",
+                "User likes Rust",
+                0.9,
+                vec!["preferences".into()],
+            )
             .unwrap();
         store
-            .append("char1", "user1", "episodic", "Discussed project plan", 0.7, vec!["project".into()])
+            .append(
+                "char1",
+                "user1",
+                "episodic",
+                "Discussed project plan",
+                0.7,
+                vec!["project".into()],
+            )
             .unwrap();
         store
-            .append("char1", "user1", "semantic", "User's name is Alice", 1.0, vec!["identity".into()])
+            .append(
+                "char1",
+                "user1",
+                "semantic",
+                "User's name is Alice",
+                1.0,
+                vec!["identity".into()],
+            )
             .unwrap();
 
         // List all
@@ -243,8 +270,12 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let store = MemoryStore::new(tmp.path().to_path_buf());
 
-        store.append("char1", "user1", "semantic", "Fact A", 0.8, vec![]).unwrap();
-        store.append("char1", "user1", "episodic", "Event B", 0.7, vec![]).unwrap();
+        store
+            .append("char1", "user1", "semantic", "Fact A", 0.8, vec![])
+            .unwrap();
+        store
+            .append("char1", "user1", "episodic", "Event B", 0.7, vec![])
+            .unwrap();
 
         // Clear only semantic
         store.clear("char1", "user1", Some("semantic")).unwrap();

--- a/crates/meux-core/src/prompt/mod.rs
+++ b/crates/meux-core/src/prompt/mod.rs
@@ -89,7 +89,17 @@ mod tests {
         let expr_mgr = ExpressionManager::new(tmp.path());
 
         char_loader
-            .create_character("Test", "A helpful companion", "model1", "jp_001", "friendly", "casual", "natural", "User", "A dev")
+            .create_character(
+                "Test",
+                "A helpful companion",
+                "model1",
+                "jp_001",
+                "friendly",
+                "casual",
+                "natural",
+                "User",
+                "A dev",
+            )
             .unwrap();
 
         let result = build_chat_prompt(
@@ -108,7 +118,10 @@ mod tests {
         assert!(result.messages.len() >= 2); // system + user at minimum
         assert_eq!(result.messages[0].role, "system");
         assert_eq!(result.messages.last().unwrap().role, "user");
-        assert_eq!(result.messages.last().unwrap().content_str(), "Hello there!");
+        assert_eq!(
+            result.messages.last().unwrap().content_str(),
+            "Hello there!"
+        );
         assert!(result.system_prompt.contains("EXPRESSION RULES"));
     }
 }

--- a/crates/meux-core/src/session/mod.rs
+++ b/crates/meux-core/src/session/mod.rs
@@ -35,9 +35,10 @@ impl SessionStore {
         user_id: &str,
         limit: Option<usize>,
     ) -> Result<Vec<SessionMessage>> {
-        let _guard = self._lock.read().map_err(|e| {
-            std::io::Error::other(e.to_string())
-        })?;
+        let _guard = self
+            ._lock
+            .read()
+            .map_err(|e| std::io::Error::other(e.to_string()))?;
 
         let path = self.session_path(character_id, user_id);
         if !path.exists() {
@@ -75,9 +76,10 @@ impl SessionStore {
         content: &str,
         metadata: Option<serde_json::Value>,
     ) -> Result<()> {
-        let _guard = self._lock.write().map_err(|e| {
-            std::io::Error::other(e.to_string())
-        })?;
+        let _guard = self
+            ._lock
+            .write()
+            .map_err(|e| std::io::Error::other(e.to_string()))?;
 
         let path = self.session_path(character_id, user_id);
         if let Some(parent) = path.parent() {
@@ -103,9 +105,10 @@ impl SessionStore {
     }
 
     pub fn clear_history(&self, character_id: &str, user_id: &str) -> Result<()> {
-        let _guard = self._lock.write().map_err(|e| {
-            std::io::Error::other(e.to_string())
-        })?;
+        let _guard = self
+            ._lock
+            .write()
+            .map_err(|e| std::io::Error::other(e.to_string()))?;
 
         let path = self.session_path(character_id, user_id);
         if path.exists() {

--- a/crates/meux-core/src/tools/clipboard.rs
+++ b/crates/meux-core/src/tools/clipboard.rs
@@ -73,7 +73,6 @@ impl Tool for ClipboardReadTool {
     }
 }
 
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/meux-core/src/tools/desktop.rs
+++ b/crates/meux-core/src/tools/desktop.rs
@@ -17,7 +17,8 @@ fn is_valid_app_name(name: &str) -> bool {
         return false;
     }
     // Allow alphanumeric, space, dot, hyphen, underscore
-    name.chars().all(|c| c.is_alphanumeric() || c == ' ' || c == '.' || c == '-' || c == '_')
+    name.chars()
+        .all(|c| c.is_alphanumeric() || c == ' ' || c == '.' || c == '-' || c == '_')
 }
 
 pub struct OpenApplicationTool;
@@ -48,7 +49,10 @@ impl Tool for OpenApplicationTool {
             .ok_or_else(|| MeuxError::Tool("Missing 'name' argument".to_string()))?;
 
         if !is_valid_app_name(name) {
-            return Err(MeuxError::Tool(format!("Invalid application name: {}", name)));
+            return Err(MeuxError::Tool(format!(
+                "Invalid application name: {}",
+                name
+            )));
         }
 
         let output = tokio::process::Command::new("open")
@@ -108,7 +112,9 @@ impl Tool for OpenUrlTool {
 
         let lower_url = url.trim().to_lowercase();
         if !lower_url.starts_with("http://") && !lower_url.starts_with("https://") {
-            return Err(MeuxError::Tool("Invalid URL scheme. Only http:// and https:// are allowed.".to_string()));
+            return Err(MeuxError::Tool(
+                "Invalid URL scheme. Only http:// and https:// are allowed.".to_string(),
+            ));
         }
 
         let output = tokio::process::Command::new("open")
@@ -193,10 +199,7 @@ impl OrganizeDesktopTool {
                 .map(|e| e.to_string_lossy().to_lowercase())
                 .unwrap_or_default();
 
-            let category = category_map
-                .get(ext.as_str())
-                .cloned()
-                .unwrap_or("Other");
+            let category = category_map.get(ext.as_str()).cloned().unwrap_or("Other");
 
             let target_dir = desktop.join(category);
             if let Err(e) = std::fs::create_dir_all(&target_dir) {
@@ -246,11 +249,16 @@ impl OrganizeDesktopTool {
 fn build_extension_map() -> HashMap<&'static str, &'static str> {
     let mut m = HashMap::new();
     // Images
-    for ext in &["png", "jpg", "jpeg", "gif", "bmp", "svg", "webp", "ico", "tiff", "heic"] {
+    for ext in &[
+        "png", "jpg", "jpeg", "gif", "bmp", "svg", "webp", "ico", "tiff", "heic",
+    ] {
         m.insert(*ext, "Images");
     }
     // Documents
-    for ext in &["pdf", "doc", "docx", "txt", "rtf", "odt", "xls", "xlsx", "ppt", "pptx", "csv", "md", "pages", "numbers", "key"] {
+    for ext in &[
+        "pdf", "doc", "docx", "txt", "rtf", "odt", "xls", "xlsx", "ppt", "pptx", "csv", "md",
+        "pages", "numbers", "key",
+    ] {
         m.insert(*ext, "Documents");
     }
     // Videos
@@ -266,7 +274,10 @@ fn build_extension_map() -> HashMap<&'static str, &'static str> {
         m.insert(*ext, "Archives");
     }
     // Code
-    for ext in &["rs", "py", "js", "ts", "jsx", "tsx", "html", "css", "json", "yaml", "yml", "toml", "sh", "go", "java", "c", "cpp", "h", "swift"] {
+    for ext in &[
+        "rs", "py", "js", "ts", "jsx", "tsx", "html", "css", "json", "yaml", "yml", "toml", "sh",
+        "go", "java", "c", "cpp", "h", "swift",
+    ] {
         m.insert(*ext, "Code");
     }
     m

--- a/crates/meux-core/src/tools/file_ops.rs
+++ b/crates/meux-core/src/tools/file_ops.rs
@@ -18,8 +18,9 @@ impl Tool for ReadFileTool {
     fn definition(&self) -> ToolDefinition {
         ToolDefinition {
             name: "read_file".to_string(),
-            description: "Read the contents of a file. Returns the text content. Limited to ~100KB."
-                .to_string(),
+            description:
+                "Read the contents of a file. Returns the text content. Limited to ~100KB."
+                    .to_string(),
             parameters: json!({
                 "type": "object",
                 "properties": {
@@ -53,11 +54,16 @@ impl Tool for ReadFileTool {
         let metadata = std::fs::metadata(path).map_err(|e| MeuxError::Tool(e.to_string()))?;
         if metadata.len() > 100_000 {
             // Read first 100KB
-            let content = std::fs::read_to_string(path).map_err(|e| MeuxError::Tool(e.to_string()))?;
+            let content =
+                std::fs::read_to_string(path).map_err(|e| MeuxError::Tool(e.to_string()))?;
             let truncated: String = content.chars().take(100_000).collect();
             return Ok(ToolResult {
                 tool_call_id: String::new(),
-                content: format!("{}\n\n[File truncated — showing first 100KB of {}]", truncated, metadata.len()),
+                content: format!(
+                    "{}\n\n[File truncated — showing first 100KB of {}]",
+                    truncated,
+                    metadata.len()
+                ),
                 success: true,
             });
         }
@@ -120,7 +126,9 @@ impl Tool for ListDirectoryTool {
         for entry in read_dir {
             let entry = entry.map_err(|e| MeuxError::Tool(e.to_string()))?;
             let name = entry.file_name().to_string_lossy().to_string();
-            let file_type = entry.file_type().map_err(|e| MeuxError::Tool(e.to_string()))?;
+            let file_type = entry
+                .file_type()
+                .map_err(|e| MeuxError::Tool(e.to_string()))?;
             if file_type.is_dir() {
                 entries.push(format!("{}/", name));
             } else {
@@ -338,7 +346,13 @@ impl Tool for FindFilesTool {
     }
 }
 
-fn find_recursive(dir: &Path, pattern: &str, results: &mut Vec<String>, max: usize, max_depth: usize) {
+fn find_recursive(
+    dir: &Path,
+    pattern: &str,
+    results: &mut Vec<String>,
+    max: usize,
+    max_depth: usize,
+) {
     if results.len() >= max || max_depth == 0 {
         return;
     }
@@ -438,8 +452,8 @@ impl Tool for EditFileTool {
             });
         }
 
-        let content = std::fs::read_to_string(file_path)
-            .map_err(|e| MeuxError::Tool(e.to_string()))?;
+        let content =
+            std::fs::read_to_string(file_path).map_err(|e| MeuxError::Tool(e.to_string()))?;
 
         if !content.contains(find) {
             return Ok(ToolResult {
@@ -456,8 +470,7 @@ impl Tool for EditFileTool {
             (content.replacen(find, replace, 1), 1)
         };
 
-        std::fs::write(file_path, &new_content)
-            .map_err(|e| MeuxError::Tool(e.to_string()))?;
+        std::fs::write(file_path, &new_content).map_err(|e| MeuxError::Tool(e.to_string()))?;
 
         Ok(ToolResult {
             tool_call_id: String::new(),
@@ -576,10 +589,14 @@ impl Tool for DeleteFileTool {
 
         // Security fix: Path Traversal Prevention
         // Canonicalize both the requested path and the base directory to resolve any ".." or symlinks.
-        let canonical_path = path.canonicalize().map_err(|e| MeuxError::Tool(format!("Failed to canonicalize path: {}", e)))?;
+        let canonical_path = path
+            .canonicalize()
+            .map_err(|e| MeuxError::Tool(format!("Failed to canonicalize path: {}", e)))?;
 
         let canonical_base = if self.base_dir.exists() {
-            self.base_dir.canonicalize().map_err(|e| MeuxError::Tool(format!("Failed to canonicalize base_dir: {}", e)))?
+            self.base_dir
+                .canonicalize()
+                .map_err(|e| MeuxError::Tool(format!("Failed to canonicalize base_dir: {}", e)))?
         } else {
             self.base_dir.clone() // Fallback if base_dir doesn't exist (though it should)
         };
@@ -587,7 +604,10 @@ impl Tool for DeleteFileTool {
         if !canonical_path.starts_with(&canonical_base) {
             return Ok(ToolResult {
                 tool_call_id: String::new(),
-                content: format!("Access denied: Path {} is outside the allowed directory.", path.display()),
+                content: format!(
+                    "Access denied: Path {} is outside the allowed directory.",
+                    path.display()
+                ),
                 success: false,
             });
         }

--- a/crates/meux-core/src/tools/mod.rs
+++ b/crates/meux-core/src/tools/mod.rs
@@ -1,8 +1,8 @@
-pub mod types;
 pub mod clipboard;
 pub mod desktop;
 pub mod file_ops;
 pub mod shell;
+pub mod types;
 pub mod web_search;
 
 use std::collections::HashMap;
@@ -119,7 +119,9 @@ impl ToolRegistry {
 
     /// Get the permission level for a tool by name.
     pub fn permission_level(&self, name: &str) -> Option<PermissionLevel> {
-        self.tools.get(name).map(|t| t.definition().permission_level)
+        self.tools
+            .get(name)
+            .map(|t| t.definition().permission_level)
     }
 
     /// Update the search provider config (called when settings change).

--- a/crates/meux-core/src/tools/shell.rs
+++ b/crates/meux-core/src/tools/shell.rs
@@ -128,8 +128,6 @@ mod tests {
     use super::*;
     use serde_json::json;
 
-
-
     struct MockCommandRunner {
         result: Result<CommandOutput>,
         // We can track the command that was run if we want, but for these tests
@@ -184,7 +182,10 @@ mod tests {
         let mock_runner = MockCommandRunner::new_success("test output", "", 0);
         let tool = RunCommandTool::with_runner(Box::new(mock_runner));
 
-        let result = tool.execute(json!({"command": "echo 'test output'"})).await.unwrap();
+        let result = tool
+            .execute(json!({"command": "echo 'test output'"}))
+            .await
+            .unwrap();
 
         assert!(result.success);
         assert_eq!(result.content, "Exit code: 0\n\ntest output");
@@ -211,7 +212,10 @@ mod tests {
         let result = tool.execute(json!({"command": "some_cmd"})).await.unwrap();
 
         assert!(!result.success);
-        assert_eq!(result.content, "Exit code: 1\n\nStdout:\nout\n\nStderr:\nerr");
+        assert_eq!(
+            result.content,
+            "Exit code: 1\n\nStdout:\nout\n\nStderr:\nerr"
+        );
     }
 
     #[tokio::test]
@@ -220,11 +224,19 @@ mod tests {
         let mock_runner = MockCommandRunner::new_success(&large_stdout, "", 0);
         let tool = RunCommandTool::with_runner(Box::new(mock_runner));
 
-        let result = tool.execute(json!({"command": "large_output_cmd"})).await.unwrap();
+        let result = tool
+            .execute(json!({"command": "large_output_cmd"}))
+            .await
+            .unwrap();
 
         assert!(result.success);
-        assert!(result.content.ends_with("\n\n[Output truncated — showing first 50KB]"));
-        assert_eq!(result.content.len(), 50000 + "\n\n[Output truncated — showing first 50KB]".len());
+        assert!(result
+            .content
+            .ends_with("\n\n[Output truncated — showing first 50KB]"));
+        assert_eq!(
+            result.content.len(),
+            50000 + "\n\n[Output truncated — showing first 50KB]".len()
+        );
     }
 
     #[tokio::test]

--- a/crates/meux-core/src/tools/web_search.rs
+++ b/crates/meux-core/src/tools/web_search.rs
@@ -37,9 +37,7 @@ impl Tool for WebSearchTool {
     fn definition(&self) -> ToolDefinition {
         ToolDefinition {
             name: "web_search".to_string(),
-            description:
-                "Search the internet and return a summary of the top results."
-                    .to_string(),
+            description: "Search the internet and return a summary of the top results.".to_string(),
             parameters: json!({
                 "type": "object",
                 "properties": {
@@ -71,7 +69,12 @@ impl Tool for WebSearchTool {
                     .serp_api_key
                     .as_deref()
                     .filter(|k| !k.is_empty())
-                    .ok_or_else(|| MeuxError::Tool("SerpAPI key not configured. Go to Settings → Web Search to add it.".to_string()))?;
+                    .ok_or_else(|| {
+                        MeuxError::Tool(
+                            "SerpAPI key not configured. Go to Settings → Web Search to add it."
+                                .to_string(),
+                        )
+                    })?;
                 search_serpapi(query, api_key).await
             }
             "exa" => {
@@ -79,7 +82,12 @@ impl Tool for WebSearchTool {
                     .exa_api_key
                     .as_deref()
                     .filter(|k| !k.is_empty())
-                    .ok_or_else(|| MeuxError::Tool("Exa API key not configured. Go to Settings → Web Search to add it.".to_string()))?;
+                    .ok_or_else(|| {
+                        MeuxError::Tool(
+                            "Exa API key not configured. Go to Settings → Web Search to add it."
+                                .to_string(),
+                        )
+                    })?;
                 search_exa(query, api_key).await
             }
             _ => search_duckduckgo(query).await,
@@ -184,7 +192,13 @@ async fn search_serpapi(query: &str, api_key: &str) -> Result<ToolResult> {
             let title = result.get("title").and_then(|t| t.as_str()).unwrap_or("");
             let link = result.get("link").and_then(|l| l.as_str()).unwrap_or("");
             let snippet = result.get("snippet").and_then(|s| s.as_str()).unwrap_or("");
-            output.push_str(&format!("{}. {}\n   {}\n   {}\n\n", i + 1, title, link, snippet));
+            output.push_str(&format!(
+                "{}. {}\n   {}\n   {}\n\n",
+                i + 1,
+                title,
+                link,
+                snippet
+            ));
         }
     }
 
@@ -247,7 +261,13 @@ async fn search_exa(query: &str, api_key: &str) -> Result<ToolResult> {
             let title = result.get("title").and_then(|t| t.as_str()).unwrap_or("");
             let url = result.get("url").and_then(|u| u.as_str()).unwrap_or("");
             let text = result.get("text").and_then(|t| t.as_str()).unwrap_or("");
-            output.push_str(&format!("{}. {}\n   {}\n   {}\n\n", i + 1, title, url, text));
+            output.push_str(&format!(
+                "{}. {}\n   {}\n   {}\n\n",
+                i + 1,
+                title,
+                url,
+                text
+            ));
         }
     }
 

--- a/crates/meux-core/src/tts/mod.rs
+++ b/crates/meux-core/src/tts/mod.rs
@@ -38,12 +38,9 @@ async fn generate_tts_once(text: &str, config: &TtsConfig) -> Result<Vec<u8>> {
 
 /// Generate TTS audio with retry (up to 2 retries with exponential backoff).
 pub async fn generate_tts_auto(text: &str, config: &TtsConfig) -> Result<Vec<u8>> {
-    crate::retry::retry_with_backoff(
-        2,
-        500,
-        crate::retry::is_retryable_tts_error,
-        || generate_tts_once(text, config),
-    )
+    crate::retry::retry_with_backoff(2, 500, crate::retry::is_retryable_tts_error, || {
+        generate_tts_once(text, config)
+    })
     .await
 }
 

--- a/crates/meux-core/src/tts/tiktok.rs
+++ b/crates/meux-core/src/tts/tiktok.rs
@@ -123,10 +123,16 @@ async fn generate_audio(text: &str, voice: &str, endpoint: &str) -> Result<Vec<u
         .await
         .map_err(|e| MeuxError::Tts(format!("TikTok TTS request failed: {e}")))?;
 
-    eprintln!("[TTS] Response status: {}, url: {}", resp.status(), resp.url());
+    eprintln!(
+        "[TTS] Response status: {}, url: {}",
+        resp.status(),
+        resp.url()
+    );
 
     // Don't check status code — just read body like the Python version
-    let bytes = resp.bytes().await
+    let bytes = resp
+        .bytes()
+        .await
         .map_err(|e| MeuxError::Tts(format!("TikTok TTS read error: {e}")))?;
 
     eprintln!("[TTS] Response body size: {} bytes", bytes.len());
@@ -136,7 +142,12 @@ async fn generate_audio(text: &str, voice: &str, endpoint: &str) -> Result<Vec<u
 
 fn extract_base64(audio_response: &[u8], endpoint_index: usize) -> Result<String> {
     let body_preview = String::from_utf8_lossy(&audio_response[..audio_response.len().min(200)]);
-    eprintln!("[TTS] Endpoint {} response ({} bytes): {}", endpoint_index, audio_response.len(), body_preview);
+    eprintln!(
+        "[TTS] Endpoint {} response ({} bytes): {}",
+        endpoint_index,
+        audio_response.len(),
+        body_preview
+    );
 
     let data: Value = serde_json::from_slice(audio_response)
         .map_err(|e| MeuxError::Tts(format!("TTS JSON parse error: {e}")))?;

--- a/src-tauri/src/commands/characters.rs
+++ b/src-tauri/src/commands/characters.rs
@@ -1,6 +1,6 @@
 use crate::AppState;
-use meux_core::character::types::{Character, CharacterSummary, ModelInfo};
 use meux_core::character::slugify;
+use meux_core::character::types::{Character, CharacterSummary, ModelInfo};
 use rfd::FileDialog;
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -9,7 +9,10 @@ use tauri::State;
 
 #[tauri::command]
 pub fn characters_list(state: State<Arc<AppState>>) -> Result<Vec<CharacterSummary>, String> {
-    state.characters.list_characters().map_err(|e| e.to_string())
+    state
+        .characters
+        .list_characters()
+        .map_err(|e| e.to_string())
 }
 
 #[tauri::command]
@@ -61,7 +64,10 @@ pub async fn models_import_live2d_dialog(
     let data_dir = state.data_dir.clone();
 
     tokio::task::spawn_blocking(move || {
-        let Some(source_dir) = FileDialog::new().set_title("Select Live2D Model Folder").pick_folder() else {
+        let Some(source_dir) = FileDialog::new()
+            .set_title("Select Live2D Model Folder")
+            .pick_folder()
+        else {
             return Ok(None);
         };
 
@@ -91,7 +97,9 @@ pub async fn models_import_live2d_dialog(
             .map_err(|e| e.to_string())?
             .into_iter()
             .find(|model| model.id == imported_id)
-            .ok_or_else(|| "Imported Live2D model was copied but could not be indexed.".to_string())?;
+            .ok_or_else(|| {
+                "Imported Live2D model was copied but could not be indexed.".to_string()
+            })?;
 
         Ok(Some(imported))
     })

--- a/src-tauri/src/commands/chat.rs
+++ b/src-tauri/src/commands/chat.rs
@@ -275,7 +275,10 @@ fn find_sentence_boundary(text: &str, allow_end_boundary: bool) -> Option<usize>
 
         let mut end = idx + ch.len_utf8();
         while let Some(&(next_idx, next_ch)) = chars.peek() {
-            if matches!(next_ch, '"' | '\'' | ')' | ']' | '}' | '\u{201D}' | '\u{2019}') {
+            if matches!(
+                next_ch,
+                '"' | '\'' | ')' | ']' | '}' | '\u{201D}' | '\u{2019}'
+            ) {
                 end = next_idx + next_ch.len_utf8();
                 chars.next();
             } else {
@@ -310,13 +313,7 @@ fn spawn_tts_for_sentence(
             Ok(audio_data) => {
                 use base64::Engine;
                 let b64 = base64::engine::general_purpose::STANDARD.encode(&audio_data);
-                let _ = app_tts.emit(
-                    "chat:audio",
-                    AudioEvent {
-                        index,
-                        data: b64,
-                    },
-                );
+                let _ = app_tts.emit("chat:audio", AudioEvent { index, data: b64 });
             }
             Err(e) => {
                 eprintln!("TTS error for sentence {}: {}", index, e);
@@ -478,7 +475,9 @@ pub async fn tool_confirm(
     approved: bool,
 ) -> Result<(), String> {
     if let Some((_, sender)) = state.pending_confirmations.remove(&request_id) {
-        sender.send(approved).map_err(|_| "Confirmation channel closed".to_string())?;
+        sender
+            .send(approved)
+            .map_err(|_| "Confirmation channel closed".to_string())?;
     }
     Ok(())
 }
@@ -525,9 +524,18 @@ async fn run_chat_stream(
     };
 
     // 4. Sync search config and get tools JSON for the LLM
-    state.tool_registry.update_search_config(config.search.clone());
-    let tools_json = state.tool_registry.openai_tools_json_filtered(&config.disabled_tools);
-    println!("[agent] LLM provider: {} | model: {} | tools enabled: {}", config.llm.base_url, config.llm.model, tools_json.len());
+    state
+        .tool_registry
+        .update_search_config(config.search.clone());
+    let tools_json = state
+        .tool_registry
+        .openai_tools_json_filtered(&config.disabled_tools);
+    println!(
+        "[agent] LLM provider: {} | model: {} | tools enabled: {}",
+        config.llm.base_url,
+        config.llm.model,
+        tools_json.len()
+    );
 
     let tts_config = config.tts.clone();
 
@@ -565,7 +573,11 @@ async fn run_chat_stream(
         // Retry streaming up to 2 times on transient errors
         for stream_attempt in 0..6u8 {
             if stream_attempt > 0 {
-                println!("[agent] stream retry attempt {}/2 (accumulated {}B text)", stream_attempt, text_content.len());
+                println!(
+                    "[agent] stream retry attempt {}/2 (accumulated {}B text)",
+                    stream_attempt,
+                    text_content.len()
+                );
                 let delay = 500 * (1 << (stream_attempt - 1));
                 tokio::time::sleep(std::time::Duration::from_millis(delay)).await;
             }
@@ -575,7 +587,10 @@ async fn run_chat_stream(
             if stream_attempt > 0 && !text_content.is_empty() {
                 // Tell the LLM to continue from where it left off
                 attempt_conv.push(ChatMessage::text("assistant", &text_content));
-                attempt_conv.push(ChatMessage::text("user", "[continue from where you left off]"));
+                attempt_conv.push(ChatMessage::text(
+                    "user",
+                    "[continue from where you left off]",
+                ));
             }
 
             let mut stream = state.llm.stream_chat_with_tools(
@@ -605,78 +620,89 @@ async fn run_chat_stream(
                     }
                 };
 
-            match event {
-                StreamEvent::TextDelta(token) => {
-                    // Emit raw text chunk to frontend
-                    let _ = app.emit("chat:text-chunk", TextChunkEvent { text: token.clone() });
+                match event {
+                    StreamEvent::TextDelta(token) => {
+                        // Emit raw text chunk to frontend
+                        let _ = app.emit(
+                            "chat:text-chunk",
+                            TextChunkEvent {
+                                text: token.clone(),
+                            },
+                        );
 
-                    text_content.push_str(&token);
-                    buffer.push_str(&token);
+                        text_content.push_str(&token);
+                        buffer.push_str(&token);
 
-                    // Process sentences from buffer
-                    drain_buffer_sentences(
-                        &app,
-                        &state,
-                        &model_id,
-                        &current_expression,
-                        &tts_config,
-                        &mut sentence_index,
-                        &mut buffer,
-                        false,
-                    );
+                        // Process sentences from buffer
+                        drain_buffer_sentences(
+                            &app,
+                            &state,
+                            &model_id,
+                            &current_expression,
+                            &tts_config,
+                            &mut sentence_index,
+                            &mut buffer,
+                            false,
+                        );
 
-                    // Check for expression tags
-                    loop {
-                        if let Some(tag_match) =
-                            find_next_tag(&buffer)
-                        {
-                            let before_tag = buffer[..tag_match.start].to_string();
+                        // Check for expression tags
+                        loop {
+                            if let Some(tag_match) = find_next_tag(&buffer) {
+                                let before_tag = buffer[..tag_match.start].to_string();
 
-                            emit_ready_sentences(
-                                &app,
-                                &state,
-                                &model_id,
-                                &current_expression,
-                                &tts_config,
-                                &mut sentence_index,
-                                &before_tag,
-                                true,
-                                true,
-                            );
+                                emit_ready_sentences(
+                                    &app,
+                                    &state,
+                                    &model_id,
+                                    &current_expression,
+                                    &tts_config,
+                                    &mut sentence_index,
+                                    &before_tag,
+                                    true,
+                                    true,
+                                );
 
-                            match tag_match.action {
-                                TagAction::SetExpression(tag_content) => {
-                                    current_expression = tag_content;
+                                match tag_match.action {
+                                    TagAction::SetExpression(tag_content) => {
+                                        current_expression = tag_content;
+                                    }
+                                    TagAction::ResetExpression => {
+                                        current_expression = "neutral".to_string();
+                                    }
                                 }
-                                TagAction::ResetExpression => {
-                                    current_expression = "neutral".to_string();
-                                }
+
+                                buffer = buffer[tag_match.end..].to_string();
+                                continue;
                             }
-
-                            buffer = buffer[tag_match.end..].to_string();
-                            continue;
+                            break;
                         }
-                        break;
+                    }
+
+                    StreamEvent::ToolCallComplete {
+                        id,
+                        name,
+                        arguments,
+                    } => {
+                        println!(
+                            "[agent] tool call received: {} id={} args={}",
+                            name, id, arguments
+                        );
+                        tool_calls.push((id, name, arguments));
+                    }
+
+                    StreamEvent::Done {
+                        finish_reason: reason,
+                    } => {
+                        println!(
+                            "[agent] stream done — finish_reason={} | tool_calls={} | text_len={}",
+                            reason,
+                            tool_calls.len(),
+                            text_content.len()
+                        );
+                        finish_reason = reason;
                     }
                 }
-
-                StreamEvent::ToolCallComplete {
-                    id,
-                    name,
-                    arguments,
-                } => {
-                    println!("[agent] tool call received: {} id={} args={}", name, id, arguments);
-                    tool_calls.push((id, name, arguments));
-                }
-
-                StreamEvent::Done {
-                    finish_reason: reason,
-                } => {
-                    println!("[agent] stream done — finish_reason={} | tool_calls={} | text_len={}", reason, tool_calls.len(), text_content.len());
-                    finish_reason = reason;
-                }
-            }
-        } // end while stream events
+            } // end while stream events
 
             if stream_error {
                 continue; // retry the stream
@@ -735,11 +761,18 @@ async fn run_chat_stream(
 
         // If no tool calls, we're done
         if finish_reason != "tool_calls" || tool_calls.is_empty() {
-            println!("[agent] no tool calls, exiting loop after iteration {}", iteration);
+            println!(
+                "[agent] no tool calls, exiting loop after iteration {}",
+                iteration
+            );
             break;
         }
 
-        println!("[agent] executing {} tool call(s) in iteration {}", tool_calls.len(), iteration);
+        println!(
+            "[agent] executing {} tool call(s) in iteration {}",
+            tool_calls.len(),
+            iteration
+        );
 
         // Separate tool calls into safe (parallel) and dangerous (need confirmation)
         let mut safe_calls: Vec<(String, String, serde_json::Value)> = Vec::new();
@@ -792,9 +825,10 @@ async fn run_chat_stream(
                         .await
                         {
                             Ok(result) => result,
-                            Err(_) => Err(meux_core::MeuxError::Tool(
-                                format!("{} timed out after 60s", tool_name),
-                            )),
+                            Err(_) => Err(meux_core::MeuxError::Tool(format!(
+                                "{} timed out after 60s",
+                                tool_name
+                            ))),
                         }
                     }
                 })
@@ -820,7 +854,10 @@ async fn run_chat_stream(
                     },
                 );
                 // Truncate for LLM context to avoid blowing up token usage
-                conversation.push(ChatMessage::tool_result(tc_id, &truncate_tool_result(&content)));
+                conversation.push(ChatMessage::tool_result(
+                    tc_id,
+                    &truncate_tool_result(&content),
+                ));
                 tool_exchanges.push(serde_json::json!({
                     "tool": tc_name,
                     "arguments": args,
@@ -846,13 +883,10 @@ async fn run_chat_stream(
             let (tx, rx) = tokio::sync::oneshot::channel::<bool>();
             state.pending_confirmations.insert(tc_id.clone(), tx);
 
-            let approved = tokio::time::timeout(
-                std::time::Duration::from_secs(30),
-                rx,
-            )
-            .await
-            .unwrap_or(Ok(false))
-            .unwrap_or(false);
+            let approved = tokio::time::timeout(std::time::Duration::from_secs(30), rx)
+                .await
+                .unwrap_or(Ok(false))
+                .unwrap_or(false);
 
             if !approved {
                 conversation.push(ChatMessage::tool_result(tc_id, "User denied this action."));
@@ -910,7 +944,10 @@ async fn run_chat_stream(
                 },
             );
             // Truncate for LLM context
-            conversation.push(ChatMessage::tool_result(tc_id, &truncate_tool_result(&content)));
+            conversation.push(ChatMessage::tool_result(
+                tc_id,
+                &truncate_tool_result(&content),
+            ));
             tool_exchanges.push(serde_json::json!({
                 "tool": tc_name,
                 "arguments": args,

--- a/src-tauri/src/commands/memory.rs
+++ b/src-tauri/src/commands/memory.rs
@@ -39,8 +39,7 @@ pub fn memory_search(
         .memories
         .list(&character_id, &user_id, None, usize::MAX)
         .map_err(|e| e.to_string())?;
-    let relevant =
-        meux_core::memory::retriever::retrieve_relevant(&query, &all_memories, 4);
+    let relevant = meux_core::memory::retriever::retrieve_relevant(&query, &all_memories, 4);
     let values: Vec<serde_json::Value> = relevant
         .iter()
         .map(|m| serde_json::to_value(m).unwrap_or_default())
@@ -49,10 +48,7 @@ pub fn memory_search(
 }
 
 #[tauri::command]
-pub fn memory_clear(
-    state: State<Arc<AppState>>,
-    character_id: String,
-) -> Result<(), String> {
+pub fn memory_clear(state: State<Arc<AppState>>, character_id: String) -> Result<(), String> {
     let user_id = get_user_id(&state);
     state
         .memories

--- a/src-tauri/src/commands/voice.rs
+++ b/src-tauri/src/commands/voice.rs
@@ -96,11 +96,10 @@ fn transcription_backends(config: &AppConfig) -> Vec<TranscriptionBackend> {
     backends
 }
 
-fn whisper_transcribe_inner(
-    ctx: &WhisperContext,
-    pcm_samples: &[f32],
-) -> Result<String, String> {
-    let mut state = ctx.create_state().map_err(|e| format!("whisper state: {e}"))?;
+fn whisper_transcribe_inner(ctx: &WhisperContext, pcm_samples: &[f32]) -> Result<String, String> {
+    let mut state = ctx
+        .create_state()
+        .map_err(|e| format!("whisper state: {e}"))?;
 
     let mut params = FullParams::new(SamplingStrategy::Greedy { best_of: 1 });
     params.set_n_threads(num_cpus());
@@ -160,10 +159,9 @@ pub async fn voice_transcribe_local(
     }
 
     // Clone the context out of state so we can move it into spawn_blocking
-    let ctx = state
-        .whisper_ctx
-        .clone()
-        .ok_or_else(|| "Whisper model not loaded. Place ggml-tiny.bin in models/whisper/".to_string())?;
+    let ctx = state.whisper_ctx.clone().ok_or_else(|| {
+        "Whisper model not loaded. Place ggml-tiny.bin in models/whisper/".to_string()
+    })?;
 
     let text = tokio::task::spawn_blocking(move || whisper_transcribe_inner(&ctx, &pcm_samples))
         .await

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -65,10 +65,7 @@ fn load_whisper_model(data_dir: &PathBuf) -> Option<Arc<WhisperContext>> {
     for path in &candidates {
         if path.exists() {
             let path_str = path.to_string_lossy().to_string();
-            match WhisperContext::new_with_params(
-                &path_str,
-                WhisperContextParameters::default(),
-            ) {
+            match WhisperContext::new_with_params(&path_str, WhisperContextParameters::default()) {
                 Ok(ctx) => {
                     println!("Whisper model loaded from: {path_str}");
                     return Some(Arc::new(ctx));

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -1,8 +1,8 @@
 use crate::window;
 use tauri::{
-    AppHandle,
     menu::{Menu, MenuItem},
     tray::{MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent},
+    AppHandle,
 };
 
 pub fn setup_tray(app: &AppHandle) -> Result<(), String> {
@@ -13,8 +13,7 @@ pub fn setup_tray(app: &AppHandle) -> Result<(), String> {
     let quit =
         MenuItem::with_id(app, "quit", "Quit", true, None::<&str>).map_err(|e| e.to_string())?;
 
-    let menu =
-        Menu::with_items(app, &[&open, &toggle_mini, &quit]).map_err(|e| e.to_string())?;
+    let menu = Menu::with_items(app, &[&open, &toggle_mini, &quit]).map_err(|e| e.to_string())?;
 
     TrayIconBuilder::new()
         .menu(&menu)

--- a/src-tauri/src/window.rs
+++ b/src-tauri/src/window.rs
@@ -1,16 +1,17 @@
 use tauri::{AppHandle, Emitter, Manager, WebviewUrl, WebviewWindowBuilder};
 
-pub fn create_mini_widget(app: &AppHandle, selected_character_id: Option<&str>) -> Result<(), String> {
+pub fn create_mini_widget(
+    app: &AppHandle,
+    selected_character_id: Option<&str>,
+) -> Result<(), String> {
     if app.get_webview_window("mini").is_some() {
         return Ok(());
     }
     let mut query = "index.html?mode=mini".to_string();
     if let Some(character_id) = selected_character_id.filter(|id| !id.is_empty()) {
-        let encoded = percent_encoding::utf8_percent_encode(
-            character_id,
-            percent_encoding::NON_ALPHANUMERIC,
-        )
-        .to_string();
+        let encoded =
+            percent_encoding::utf8_percent_encode(character_id, percent_encoding::NON_ALPHANUMERIC)
+                .to_string();
         query.push_str("&character=");
         query.push_str(&encoded);
     }
@@ -53,11 +54,19 @@ struct ModeChangedEvent {
 }
 
 #[tauri::command]
-pub fn window_toggle_mini(app: AppHandle, selected_character_id: Option<String>) -> Result<(), String> {
+pub fn window_toggle_mini(
+    app: AppHandle,
+    selected_character_id: Option<String>,
+) -> Result<(), String> {
     if app.get_webview_window("mini").is_some() {
         close_mini_widget(&app);
         show_main_window(&app);
-        let _ = app.emit("app:mode-changed", ModeChangedEvent { mode: "full".to_string() });
+        let _ = app.emit(
+            "app:mode-changed",
+            ModeChangedEvent {
+                mode: "full".to_string(),
+            },
+        );
     } else {
         hide_main_window(&app);
         create_mini_widget(&app, selected_character_id.as_deref())?;
@@ -69,7 +78,12 @@ pub fn window_toggle_mini(app: AppHandle, selected_character_id: Option<String>)
 pub fn window_expand(app: AppHandle) -> Result<(), String> {
     close_mini_widget(&app);
     show_main_window(&app);
-    let _ = app.emit("app:mode-changed", ModeChangedEvent { mode: "full".to_string() });
+    let _ = app.emit(
+        "app:mode-changed",
+        ModeChangedEvent {
+            mode: "full".to_string(),
+        },
+    );
     Ok(())
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a **GitHub Actions CI** workflow for pushes and pull requests targeting `main`.

## What runs in CI

**Frontend job**
- `npm ci`, `npm run build` (TypeScript + Vite production build), `npm test` (Vitest)

**Rust job** (Ubuntu, same WebKit / native stack as release)
- System packages: build tools, OpenSSL, Clang, WebKitGTK, appindicator, etc.
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `npm run tauri build` as an integration smoke build

## Other changes

`cargo fmt` was applied across the Rust workspace so the new **fmt check** step passes consistently.

## Notes

- Concurrency is enabled so new pushes cancel in-progress runs for the same PR/branch.
- If CI fails on **clippy** strictness, we can relax `-D warnings` or fix lints in follow-ups.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3f7ade56-caf9-48be-98a7-464745594030"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3f7ade56-caf9-48be-98a7-464745594030"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

