### PR TITLE
Fix CI Rust job: clippy cleanups and Linux linker dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,9 @@ concurrency:
 
 env:
   CARGO_TERM_COLOR: always
+  # whisper-rs-sys uses CMake; default clang++ on some images fails to link -lstdc++
+  CC: gcc
+  CXX: g++
 
 jobs:
   frontend:
@@ -45,6 +48,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y \
             build-essential \
+            g++ \
             cmake \
             pkg-config \
             libssl-dev \
@@ -53,7 +57,19 @@ jobs:
             libwebkit2gtk-4.1-dev \
             libappindicator3-dev \
             librsvg2-dev \
-            patchelf
+            patchelf \
+            libgtk-3-dev \
+            libgdk-pixbuf-2.0-dev \
+            libglib2.0-dev \
+            libcairo2-dev \
+            libpango1.0-dev \
+            libsoup-3.0-dev
+
+      # Rust 1.71+ uses rust-lld; it does not search GCC's private libstdc++ dir, so linking whisper-rs-sys fails without this.
+      - name: Rust linker search path for libstdc++
+        run: |
+          gcc_dir=$(dirname "$(gcc -print-file-name=libstdc++.so)")
+          echo "RUSTFLAGS=-C link-arg=-L${gcc_dir}" >> "$GITHUB_ENV"
 
       - uses: actions/setup-node@v4
         with:

--- a/crates/meux-core/src/character/mod.rs
+++ b/crates/meux-core/src/character/mod.rs
@@ -142,6 +142,7 @@ impl CharacterLoader {
     }
 
     /// Create a new character from basic parameters. Returns the character id.
+    #[allow(clippy::too_many_arguments)] // Mirrors the onboarding form; grouping would churn many call sites.
     pub fn create_character(
         &self,
         name: &str,

--- a/crates/meux-core/src/context/mod.rs
+++ b/crates/meux-core/src/context/mod.rs
@@ -32,7 +32,7 @@ fn message_tokens(msg: &ChatMessage) -> usize {
 ///
 /// This preserves the conversation structure (the LLM still sees that a tool
 /// was called and returned something) without wasting tokens on the full output.
-pub fn compress_stale_tool_results(messages: &mut Vec<ChatMessage>, recent_tool_turns: usize) {
+pub fn compress_stale_tool_results(messages: &mut [ChatMessage], recent_tool_turns: usize) {
     // Find all tool-result messages (role == "tool") and count from the end
     let tool_indices: Vec<usize> = messages
         .iter()

--- a/crates/meux-core/src/memory/store.rs
+++ b/crates/meux-core/src/memory/store.rs
@@ -1,5 +1,6 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use std::cmp::Reverse;
 use std::io::{BufRead, Write};
 use std::path::PathBuf;
 use std::sync::RwLock;
@@ -167,7 +168,7 @@ impl MemoryStore {
             }
         }
 
-        memories.sort_by(|a, b| b.ts.cmp(&a.ts));
+        memories.sort_by_key(|m| Reverse(m.ts));
         memories.truncate(limit);
         Ok(memories)
     }

--- a/crates/meux-core/src/prompt/mod.rs
+++ b/crates/meux-core/src/prompt/mod.rs
@@ -15,37 +15,42 @@ pub struct ChatPromptResult {
     pub memory_prompt: String,
 }
 
-pub fn build_chat_prompt(
-    character_loader: &CharacterLoader,
-    session_store: &SessionStore,
-    memory_store: &MemoryStore,
-    _expression_manager: &ExpressionManager,
-    character_id: &str,
-    user_id: &str,
-    user_message: &str,
-    history_limit: Option<usize>,
-    memory_limit: Option<usize>,
-) -> Result<ChatPromptResult> {
-    let history_limit = history_limit.unwrap_or(DEFAULT_HISTORY_LIMIT);
-    let memory_limit = memory_limit.unwrap_or(DEFAULT_MEMORY_LIMIT);
+/// Inputs for [`build_chat_prompt`] (keeps the public API readable for Clippy).
+pub struct ChatPromptParams<'a> {
+    pub character_loader: &'a CharacterLoader,
+    pub session_store: &'a SessionStore,
+    pub memory_store: &'a MemoryStore,
+    pub _expression_manager: &'a ExpressionManager,
+    pub character_id: &'a str,
+    pub user_id: &'a str,
+    pub user_message: &'a str,
+    pub history_limit: Option<usize>,
+    pub memory_limit: Option<usize>,
+}
+
+pub fn build_chat_prompt(p: ChatPromptParams<'_>) -> Result<ChatPromptResult> {
+    let history_limit = p.history_limit.unwrap_or(DEFAULT_HISTORY_LIMIT);
+    let memory_limit = p.memory_limit.unwrap_or(DEFAULT_MEMORY_LIMIT);
 
     // 1. Load character
-    let char_data = character_loader.load_character(character_id)?;
+    let char_data = p.character_loader.load_character(p.character_id)?;
 
     // 2. Build system prompt with global expressions
     let global_exprs: Vec<&str> = GLOBAL_EXPRESSIONS.to_vec();
     let system_prompt = character::build_system_prompt(&char_data, &global_exprs);
 
     // 3. Ensure memory store exists, list all memories, retrieve relevant ones
-    let _ = memory_store.ensure_store(character_id, user_id);
-    let all_memories = memory_store.list(character_id, user_id, None, 100)?;
-    let relevant = retriever::retrieve_relevant(user_message, &all_memories, memory_limit);
+    let _ = p.memory_store.ensure_store(p.character_id, p.user_id);
+    let all_memories = p.memory_store.list(p.character_id, p.user_id, None, 100)?;
+    let relevant = retriever::retrieve_relevant(p.user_message, &all_memories, memory_limit);
 
     // 4. Format memory prompt
     let memory_prompt = retriever::format_memory_prompt(&relevant);
 
     // 5. Load session history
-    let history = session_store.load_history(character_id, user_id, Some(history_limit))?;
+    let history = p
+        .session_store
+        .load_history(p.character_id, p.user_id, Some(history_limit))?;
 
     // 6. Assemble messages array
     let mut messages = Vec::new();
@@ -66,7 +71,7 @@ pub fn build_chat_prompt(
     }
 
     // Current user message
-    messages.push(ChatMessage::text("user", user_message));
+    messages.push(ChatMessage::text("user", p.user_message));
 
     Ok(ChatPromptResult {
         messages,
@@ -102,17 +107,17 @@ mod tests {
             )
             .unwrap();
 
-        let result = build_chat_prompt(
-            &char_loader,
-            &session_store,
-            &memory_store,
-            &expr_mgr,
-            "test",
-            "default-user",
-            "Hello there!",
-            None,
-            None,
-        )
+        let result = build_chat_prompt(ChatPromptParams {
+            character_loader: &char_loader,
+            session_store: &session_store,
+            memory_store: &memory_store,
+            _expression_manager: &expr_mgr,
+            character_id: "test",
+            user_id: "default-user",
+            user_message: "Hello there!",
+            history_limit: None,
+            memory_limit: None,
+        })
         .unwrap();
 
         assert!(result.messages.len() >= 2); // system + user at minimum

--- a/crates/meux-core/src/tools/clipboard.rs
+++ b/crates/meux-core/src/tools/clipboard.rs
@@ -73,51 +73,6 @@ impl Tool for ClipboardReadTool {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use serde_json::json;
-
-    #[tokio::test]
-    async fn test_clipboard_read_definition() {
-        let tool = ClipboardReadTool;
-        let def = tool.definition();
-
-        assert_eq!(def.name, "clipboard_read");
-        assert_eq!(def.permission_level, PermissionLevel::Safe);
-        assert_eq!(def.parameters["type"], "object");
-        assert!(def.parameters["required"].as_array().unwrap().is_empty());
-    }
-
-    #[tokio::test]
-    async fn test_clipboard_write_definition() {
-        let tool = ClipboardWriteTool;
-        let def = tool.definition();
-
-        assert_eq!(def.name, "clipboard_write");
-        assert_eq!(def.permission_level, PermissionLevel::Cautious);
-        assert_eq!(def.parameters["type"], "object");
-
-        let required = def.parameters["required"].as_array().unwrap();
-        assert_eq!(required.len(), 1);
-        assert_eq!(required[0].as_str().unwrap(), "content");
-    }
-
-    #[tokio::test]
-    async fn test_clipboard_write_missing_content() {
-        let tool = ClipboardWriteTool;
-        let args = json!({});
-
-        let result = tool.execute(args).await;
-        assert!(result.is_err());
-        if let Err(MeuxError::Tool(msg)) = result {
-            assert_eq!(msg, "Missing 'content' argument");
-        } else {
-            panic!("Expected Tool error with missing content message");
-        }
-    }
-}
-
 // ---------------------------------------------------------------------------
 // clipboard_write
 // ---------------------------------------------------------------------------
@@ -179,6 +134,51 @@ impl Tool for ClipboardWriteTool {
                 content: "Failed to write to clipboard.".to_string(),
                 success: false,
             })
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[tokio::test]
+    async fn test_clipboard_read_definition() {
+        let tool = ClipboardReadTool;
+        let def = tool.definition();
+
+        assert_eq!(def.name, "clipboard_read");
+        assert_eq!(def.permission_level, PermissionLevel::Safe);
+        assert_eq!(def.parameters["type"], "object");
+        assert!(def.parameters["required"].as_array().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_clipboard_write_definition() {
+        let tool = ClipboardWriteTool;
+        let def = tool.definition();
+
+        assert_eq!(def.name, "clipboard_write");
+        assert_eq!(def.permission_level, PermissionLevel::Cautious);
+        assert_eq!(def.parameters["type"], "object");
+
+        let required = def.parameters["required"].as_array().unwrap();
+        assert_eq!(required.len(), 1);
+        assert_eq!(required[0].as_str().unwrap(), "content");
+    }
+
+    #[tokio::test]
+    async fn test_clipboard_write_missing_content() {
+        let tool = ClipboardWriteTool;
+        let args = json!({});
+
+        let result = tool.execute(args).await;
+        assert!(result.is_err());
+        if let Err(MeuxError::Tool(msg)) = result {
+            assert_eq!(msg, "Missing 'content' argument");
+        } else {
+            panic!("Expected Tool error with missing content message");
         }
     }
 }

--- a/crates/meux-core/src/tools/shell.rs
+++ b/crates/meux-core/src/tools/shell.rs
@@ -63,6 +63,12 @@ impl RunCommandTool {
     }
 }
 
+impl Default for RunCommandTool {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 #[async_trait]
 impl Tool for RunCommandTool {
     fn definition(&self) -> ToolDefinition {

--- a/src-tauri/src/commands/characters.rs
+++ b/src-tauri/src/commands/characters.rs
@@ -24,6 +24,7 @@ pub fn characters_get(state: State<Arc<AppState>>, id: String) -> Result<Charact
 }
 
 #[tauri::command]
+#[allow(clippy::too_many_arguments)] // Tauri command mirrors frontend create form fields.
 pub fn characters_create(
     state: State<Arc<AppState>>,
     name: String,

--- a/src-tauri/src/commands/chat.rs
+++ b/src-tauri/src/commands/chat.rs
@@ -352,6 +352,7 @@ fn emit_sentence_chunk(
     *sentence_index += 1;
 }
 
+#[allow(clippy::too_many_arguments)]
 fn emit_ready_sentences(
     app: &AppHandle,
     state: &Arc<AppState>,
@@ -392,6 +393,7 @@ fn emit_ready_sentences(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn drain_buffer_sentences(
     app: &AppHandle,
     state: &Arc<AppState>,
@@ -501,17 +503,17 @@ async fn run_chat_stream(
     let model_id = character.live2d_model.clone();
 
     // 2. Build prompt
-    let prompt_result = meux_core::prompt::build_chat_prompt(
-        &state.characters,
-        &state.sessions,
-        &state.memories,
-        &state.expressions,
-        &character_id,
-        &user_id,
-        &message,
-        None,
-        None,
-    )
+    let prompt_result = meux_core::prompt::build_chat_prompt(meux_core::prompt::ChatPromptParams {
+        character_loader: &state.characters,
+        session_store: &state.sessions,
+        memory_store: &state.memories,
+        _expression_manager: &state.expressions,
+        character_id: &character_id,
+        user_id: &user_id,
+        user_message: &message,
+        history_limit: None,
+        memory_limit: None,
+    })
     .map_err(|e| e.to_string())?;
 
     // 3. Create LlmStreamConfig

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -10,7 +10,7 @@ use meux_core::llm::OpenAiCompatClient;
 use meux_core::memory::store::MemoryStore;
 use meux_core::session::SessionStore;
 use meux_core::tools::ToolRegistry;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use tauri::Manager;
 use whisper_rs::{WhisperContext, WhisperContextParameters};
@@ -54,7 +54,7 @@ fn resolve_asset_path(state: tauri::State<Arc<AppState>>, path: String) -> Resul
     }
 }
 
-fn load_whisper_model(data_dir: &PathBuf) -> Option<Arc<WhisperContext>> {
+fn load_whisper_model(data_dir: &Path) -> Option<Arc<WhisperContext>> {
     // Search for model in multiple locations
     let candidates = [
         data_dir.join("models/whisper/ggml-tiny.bin"),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The **Rust** CI job was failing on `cargo clippy -D warnings` (Clippy 1.95) and could also fail linking **`whisper-rs-sys`** on Ubuntu when the default C++ toolchain is **clang + lld** without a visible **libstdc++** search path.

## Changes

### Workflow (`.github/workflows/ci.yml`)

- Install full GTK / WebKit stack: **libgtk-3-dev**, **libsoup-3.0-dev**, **cairo**, **pango**, **glib**, **gdk-pixbuf**, plus existing webkit/appindicator packages.
- Install **g++** and set **`CC`/`CXX` to gcc/g++** so whisper’s CMake uses a reliable C++ toolchain.
- Append **`RUSTFLAGS=-C link-arg=-L<gcc libstdc++ dir>`** so **rust-lld** can resolve **`-lstdc++`** when linking the desktop crate.

### Code (Clippy / structure)

- **`memory/store`**: `sort_by_key` + `Reverse` instead of `sort_by` (`unnecessary_sort_by`).
- **`context`**: `compress_stale_tool_results` takes `&mut [ChatMessage]` (`ptr_arg`).
- **`prompt`**: `build_chat_prompt` now takes **`ChatPromptParams`** to satisfy **`too_many_arguments`**; Tauri `chat` command updated.
- **`shell`**: **`Default`** for **`RunCommandTool`** (`new_without_default`).
- **`clipboard`**: move **`ClipboardWriteTool`** above **`#[cfg(test)]`** (`items_after_test_module`).
- **`character`**: targeted **`allow(too_many_arguments)`** on **`create_character`** (mirrors onboarding form).
- **`src-tauri`**: **`allow(too_many_arguments)`** on **`characters_create`** and streaming helpers; **`load_whisper_model`** takes **`&Path`**.

## Verification

Locally (with deps installed): **`cargo fmt --check`**, **`cargo clippy --workspace --all-targets -- -D warnings`**, **`cargo test --workspace`** with the same **`RUSTFLAGS`** pattern as CI.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3f7ade56-caf9-48be-98a7-464745594030"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3f7ade56-caf9-48be-98a7-464745594030"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

