### PR TITLE
⚡ Bolt: Optimize ChatPanel to prevent O(N) keystroke re-renders

### DIFF
--- a/src/components/ChatPanel.tsx
+++ b/src/components/ChatPanel.tsx
@@ -111,6 +111,105 @@ const MarkdownContent = memo(({ content }: { content: string }) => (
   </ReactMarkdown>
 ));
 
+interface ChatInputProps {
+  loading: boolean;
+  onSend: (text: string) => void;
+  onTypingChange: (isTyping: boolean) => void;
+  listening: boolean;
+  onMicToggle: () => void;
+  ttsLoading?: boolean;
+  inputRef?: React.RefObject<HTMLInputElement | null>;
+}
+
+// Extracted to prevent the entire ChatPanel (and all of its child message components)
+// from re-rendering on every keystroke. By managing local text state here, only
+// this component re-renders when the user types.
+const ChatInput = memo(function ChatInput({
+  loading,
+  onSend,
+  onTypingChange,
+  listening,
+  onMicToggle,
+  ttsLoading = false,
+  inputRef: externalInputRef,
+}: ChatInputProps) {
+  const [input, setInput] = useState("");
+  const typingTimeoutRef = useRef<number | null>(null);
+  const internalInputRef = useRef<HTMLInputElement>(null);
+  const inputRef = externalInputRef || internalInputRef;
+
+  useEffect(() => {
+    return () => {
+      if (typingTimeoutRef.current) clearTimeout(typingTimeoutRef.current);
+    };
+  }, []);
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setInput(e.target.value);
+    onTypingChange(true);
+    if (typingTimeoutRef.current) {
+      clearTimeout(typingTimeoutRef.current);
+    }
+    typingTimeoutRef.current = window.setTimeout(() => {
+      onTypingChange(false);
+    }, 1500);
+  };
+
+  const handleSubmit = useCallback(
+    (e: React.FormEvent) => {
+      e.preventDefault();
+      if (!input.trim() || loading) return;
+      onTypingChange(false);
+      if (typingTimeoutRef.current) {
+        clearTimeout(typingTimeoutRef.current);
+      }
+      onSend(input.trim());
+      setInput("");
+      inputRef.current?.focus();
+    },
+    [input, loading, onSend, onTypingChange, inputRef],
+  );
+
+  const isProcessing = loading || ttsLoading;
+
+  return (
+    <div className="w-full bg-white/90 backdrop-blur-md pb-4 pt-2 border-t border-slate-100/50">
+      <form
+        onSubmit={handleSubmit}
+        className="px-4 flex items-center gap-2"
+      >
+        <div className="flex-1 relative group">
+          <input
+            ref={inputRef}
+            type="text"
+            value={input}
+            onChange={handleInputChange}
+            placeholder="Say something..."
+            className="w-full bg-slate-50 hover:bg-slate-100/80 text-slate-700 rounded-2xl pl-5 pr-12 py-3 text-[14px] outline-none transition-all placeholder-slate-400 border border-slate-100 disabled:opacity-50 focus:bg-white focus:ring-2 focus:ring-blue-100 focus:border-blue-200"
+            disabled={isProcessing}
+          />
+          <div className="absolute right-2 top-1/2 -translate-y-1/2">
+            <MicButton listening={listening} onToggle={onMicToggle} />
+          </div>
+        </div>
+        <button
+          type="submit"
+          disabled={isProcessing || !input.trim()}
+          className="bg-blue-500 hover:bg-blue-600 disabled:bg-slate-100 disabled:text-slate-400 disabled:shadow-none text-white rounded-2xl w-11 h-11 flex items-center justify-center transition-all shadow-md shadow-blue-500/20 hover:-translate-y-0.5 active:translate-y-0"
+        >
+          {isProcessing ? (
+            <span className="w-4 h-4 border-2 border-slate-300 border-t-white rounded-full animate-spin" />
+          ) : (
+            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M6 12L3.269 3.126A59.768 59.768 0 0121.485 12 59.77 59.77 0 013.27 20.876L5.999 12zm0 0h7.5" />
+            </svg>
+          )}
+        </button>
+      </form>
+    </div>
+  );
+});
+
 const MessageBubble = memo(function MessageBubble({
   msg,
   characterName,
@@ -171,51 +270,13 @@ export function ChatPanel({
   speaking = false,
   toolCalls = [],
   onToolConfirm,
-  inputRef: externalInputRef,
+  inputRef,
 }: Props) {
-  const [input, setInput] = useState("");
   const messagesEndRef = useRef<HTMLDivElement>(null);
-  const typingTimeoutRef = useRef<number | null>(null);
-  const internalInputRef = useRef<HTMLInputElement>(null);
-  const inputRef = externalInputRef || internalInputRef;
-
-  useEffect(() => {
-    return () => {
-      if (typingTimeoutRef.current) clearTimeout(typingTimeoutRef.current);
-    };
-  }, []);
 
   useEffect(() => {
     messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
   }, [messages, streamingText, toolCalls]);
-
-  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setInput(e.target.value);
-    onTypingChange(true);
-    if (typingTimeoutRef.current) {
-      clearTimeout(typingTimeoutRef.current);
-    }
-    typingTimeoutRef.current = window.setTimeout(() => {
-      onTypingChange(false);
-    }, 1500);
-  };
-
-  const handleSubmit = useCallback(
-    (e: React.FormEvent) => {
-      e.preventDefault();
-      if (!input.trim() || loading) return;
-      onTypingChange(false);
-      if (typingTimeoutRef.current) {
-        clearTimeout(typingTimeoutRef.current);
-      }
-      onSend(input.trim());
-      setInput("");
-      inputRef.current?.focus();
-    },
-    [input, loading, onSend, onTypingChange],
-  );
-
-  const isProcessing = loading || ttsLoading;
 
   return (
     <div className="flex-1 flex flex-col bg-transparent relative h-full">
@@ -315,40 +376,15 @@ export function ChatPanel({
       )}
 
       {/* Input Form */}
-      <div className="w-full bg-white/90 backdrop-blur-md pb-4 pt-2 border-t border-slate-100/50">
-        <form
-          onSubmit={handleSubmit}
-          className="px-4 flex items-center gap-2"
-        >
-          <div className="flex-1 relative group">
-            <input
-              ref={inputRef}
-              type="text"
-              value={input}
-              onChange={handleInputChange}
-              placeholder="Say something..."
-              className="w-full bg-slate-50 hover:bg-slate-100/80 text-slate-700 rounded-2xl pl-5 pr-12 py-3 text-[14px] outline-none transition-all placeholder-slate-400 border border-slate-100 disabled:opacity-50 focus:bg-white focus:ring-2 focus:ring-blue-100 focus:border-blue-200"
-              disabled={isProcessing}
-            />
-            <div className="absolute right-2 top-1/2 -translate-y-1/2">
-              <MicButton listening={listening} onToggle={onMicToggle} />
-            </div>
-          </div>
-          <button
-            type="submit"
-            disabled={isProcessing || !input.trim()}
-            className="bg-blue-500 hover:bg-blue-600 disabled:bg-slate-100 disabled:text-slate-400 disabled:shadow-none text-white rounded-2xl w-11 h-11 flex items-center justify-center transition-all shadow-md shadow-blue-500/20 hover:-translate-y-0.5 active:translate-y-0"
-          >
-            {isProcessing ? (
-              <span className="w-4 h-4 border-2 border-slate-300 border-t-white rounded-full animate-spin" />
-            ) : (
-              <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M6 12L3.269 3.126A59.768 59.768 0 0121.485 12 59.77 59.77 0 013.27 20.876L5.999 12zm0 0h7.5" />
-              </svg>
-            )}
-          </button>
-        </form>
-      </div>
+      <ChatInput
+        loading={loading}
+        onSend={onSend}
+        onTypingChange={onTypingChange}
+        listening={listening}
+        onMicToggle={onMicToggle}
+        ttsLoading={ttsLoading}
+        inputRef={inputRef}
+      />
     </div>
   );
 }


### PR DESCRIPTION
💡 **What:** Extracted the text input state (`input`) and form UI from the main `ChatPanel` component into a new, isolated `ChatInput` memoized component.
🎯 **Why:** Previously, typing in the chat box triggered a re-render of the entire `ChatPanel` on every single keystroke. Even with memoized child components, this caused significant O(N) reconciliation overhead as the message list grew, making the typing experience sluggish.
📊 **Impact:** Reduces re-renders of the main chat container by ~100% during typing. Now, only the small `ChatInput` component re-renders when the user types.
🔬 **Measurement:** Verify by typing rapidly in the chat box with a large history. React DevTools profiler will show only `ChatInput` rendering instead of the whole `ChatPanel` tree.

---
*PR created automatically by Jules for task [14222046817094003877](https://jules.google.com/task/14222046817094003877) started by @meet447*