### PR TITLE
⚡ Bolt: Cache debug arrays in useVRM to prevent O(N) recreations

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -13,3 +13,7 @@
 ## 2024-05-18 - ChatPanel React List Re-renders
 **Learning:** Managing text input state at the top level of a chat panel (`ChatPanel.tsx`) causes O(N) re-renders (where N is the number of messages) on every single keystroke. This causes a significant performance bottleneck, as all historical `MessageBubble` and `ToolCallBubble` components re-render unless explicitly memoized.
 **Action:** Always wrap heavy list item components (like message bubbles) in `React.memo` when the parent container handles frequently updating state like text input, to prevent massive unnecessary re-render trees.
+
+## 2024-05-18 - Caching Static Metadata for React Hook Rendering
+**Learning:** When returning static metadata (like available expressions or animations) in frequent polling or animation loops (e.g., `getDebug` called via `setInterval` every 200ms), caching the arrays in `useRef` upon load instead of recreating them from iterables (e.g., `[...map.keys()]` or `Object.keys()`)
+**Action:** Always cache stable arrays retrieved from objects/maps into `useRef` instances instead of dynamically deriving them inside functions invoked frequently.

--- a/src/hooks/useVRM.ts
+++ b/src/hooks/useVRM.ts
@@ -34,6 +34,10 @@ export function useVRM(canvasRef: React.RefObject<HTMLCanvasElement | null>) {
   const speakingRef = useRef(false);
   const speakStartRef = useRef(0);
 
+  // Debug info caches
+  const availableExpressionsRef = useRef<string[]>([]);
+  const availableMotionGroupsRef = useRef<string[]>([]);
+
   // Blinking
   const lastBlinkTimeRef = useRef(Date.now());
   const nextBlinkDelayRef = useRef(2000 + Math.random() * 4000);
@@ -422,9 +426,13 @@ export function useVRM(canvasRef: React.RefObject<HTMLCanvasElement | null>) {
 
         clockRef.current = new THREE.Clock();
 
+        // Cache available expressions and motion groups
+        availableExpressionsRef.current = Object.keys(vrm.expressionManager?.expressionMap || {});
+        availableMotionGroupsRef.current = [...clipsRef.current.keys()];
+
         console.log("[VRM] Model loaded:", modelPath);
-        console.log("[VRM] Expressions:", Object.keys(vrm.expressionManager?.expressionMap || {}));
-        console.log("[VRM] Animations:", [...clipsRef.current.keys()]);
+        console.log("[VRM] Expressions:", availableExpressionsRef.current);
+        console.log("[VRM] Animations:", availableMotionGroupsRef.current);
 
         startAnimationLoop();
       } catch (err) {
@@ -543,8 +551,8 @@ export function useVRM(canvasRef: React.RefObject<HTMLCanvasElement | null>) {
     lipSyncActive: lipSyncActiveRef.current,
     mouthValue: Math.round(mouthValueRef.current * 100) / 100,
     mappingEmotions: [],
-    availableExpressions: Object.keys(vrmRef.current?.expressionManager?.expressionMap || {}),
-    availableMotionGroups: [...clipsRef.current.keys()],
+    availableExpressions: availableExpressionsRef.current,
+    availableMotionGroups: availableMotionGroupsRef.current,
     lastError: "",
   }), []);
 


### PR DESCRIPTION
**What:**
Modified `src/hooks/useVRM.ts` to cache the arrays for `availableExpressions` and `availableMotionGroups` inside `useRef` hooks rather than deriving them dynamically inside the `getDebug` function.

**Why:**
The `getDebug` function is called every 200ms by a `setInterval` in `src/components/VRMCanvas.tsx`. Calling `Object.keys()` and spreading the map keys array `[...clipsRef.current.keys()]` inside `getDebug` creates new arrays on every single invocation, leading to unnecessary O(N) array allocations and excessive Garbage Collection overhead that can cause frame drops in 3D apps.

**Measured Improvement:**
Reduces the array allocations to zero during the polling loop. Array creation now happens exactly once when the model and its animations are successfully loaded.

---
*PR created automatically by Jules for task [142220924411744382](https://jules.google.com/task/142220924411744382) started by @meet447*