### PR TITLE
⚡ Bolt: Cache static debug metadata in useVRM to prevent array recreation

### DIFF
--- a/src/hooks/useVRM.ts
+++ b/src/hooks/useVRM.ts
@@ -40,6 +40,9 @@ export function useVRM(canvasRef: React.RefObject<HTMLCanvasElement | null>) {
   const blinkValueRef = useRef(0);
   const blinkClosingRef = useRef(false);
 
+  const cachedExpressionsRef = useRef<string[]>([]);
+  const cachedMotionsRef = useRef<string[]>([]);
+
   useEffect(() => {
     return () => {
       animatingRef.current = false;
@@ -422,9 +425,12 @@ export function useVRM(canvasRef: React.RefObject<HTMLCanvasElement | null>) {
 
         clockRef.current = new THREE.Clock();
 
+        cachedExpressionsRef.current = Object.keys(vrm.expressionManager?.expressionMap || {});
+        cachedMotionsRef.current = [...clipsRef.current.keys()];
+
         console.log("[VRM] Model loaded:", modelPath);
-        console.log("[VRM] Expressions:", Object.keys(vrm.expressionManager?.expressionMap || {}));
-        console.log("[VRM] Animations:", [...clipsRef.current.keys()]);
+        console.log("[VRM] Expressions:", cachedExpressionsRef.current);
+        console.log("[VRM] Animations:", cachedMotionsRef.current);
 
         startAnimationLoop();
       } catch (err) {
@@ -543,8 +549,8 @@ export function useVRM(canvasRef: React.RefObject<HTMLCanvasElement | null>) {
     lipSyncActive: lipSyncActiveRef.current,
     mouthValue: Math.round(mouthValueRef.current * 100) / 100,
     mappingEmotions: [],
-    availableExpressions: Object.keys(vrmRef.current?.expressionManager?.expressionMap || {}),
-    availableMotionGroups: [...clipsRef.current.keys()],
+    availableExpressions: cachedExpressionsRef.current,
+    availableMotionGroups: cachedMotionsRef.current,
     lastError: "",
   }), []);
 


### PR DESCRIPTION
💡 What: Caches the `availableExpressions` and `availableMotionGroups` array creation in `useVRM.ts` onto `useRef`s during `loadModel` instead of evaluating `Object.keys()` and `[...clipsRef.current.keys()]` on every debug tick.

🎯 Why: The `getDebug` function is called repeatedly inside a `setInterval` when the debug view is active. Dynamically iterating iterables and evaluating `Object.keys()` inside a polling loop creates new array allocations every time, causing unnecessary garbage collection pressure and CPU overhead.

📊 Impact: Eliminates redundant O(N) loop array creations and object key mappings, reducing GC churn inside the debug interval loop.

🔬 Measurement: Verify by opening the Live2D/VRM debug overlay in the app and observing reduced memory allocation churn in dev tools compared to baseline.

---
*PR created automatically by Jules for task [2751218841372504090](https://jules.google.com/task/2751218841372504090) started by @meet447*