### PR TITLE
Add AGENTS.md with Cursor Cloud development instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,48 @@
+# MeuxCompanion — Agent Development Guide
+
+## Cursor Cloud specific instructions
+
+### Overview
+
+MeuxCompanion is a local-first AI companion desktop app built with **Tauri 2** (Rust backend + React/Vite frontend). There are no databases, Docker containers, or microservices — it is a single self-contained desktop application.
+
+### Project layout
+
+| Path | Language | Purpose |
+|---|---|---|
+| `src/` | TypeScript/React | Vite frontend (React 19, Tailwind, Three.js, PixiJS/Live2D) |
+| `src-tauri/` | Rust | Tauri 2 shell — desktop window, system tray, Whisper voice, commands |
+| `crates/meux-core/` | Rust | Core logic — LLM client, memory, sessions, characters, TTS, tools |
+
+### Running in headless Cloud VM
+
+The full desktop app (`npm run tauri dev`) requires a display. In a headless Cloud VM:
+
+- **Frontend only:** `npm run dev` starts the Vite dev server on `http://localhost:1420`. The UI renders in a browser but Tauri backend calls (file I/O, Whisper, etc.) will fail gracefully.
+- **Rust compilation and tests work normally** without a display.
+
+### Lint, test, and build commands
+
+See `package.json` scripts and the CI workflow at `.github/workflows/ci.yml`.
+
+- **Frontend tests:** `npm test` (Vitest, 38 tests)
+- **Frontend build:** `npm run build` (tsc + vite build)
+- **Rust format check:** `cargo fmt --all -- --check`
+- **Rust lint:** `cargo clippy --workspace --all-targets -- -D warnings`
+- **Rust tests:** `cargo test --workspace` (55 tests across meux-core and tauri crate)
+
+### Rust build environment variables
+
+The `whisper-rs-sys` crate requires CMake and g++ for its C++ build. Set these environment variables before any `cargo` command:
+
+```bash
+export CC=gcc CXX=g++
+gcc_dir=$(dirname "$(gcc -print-file-name=libstdc++.so)")
+export RUSTFLAGS="-C link-arg=-L${gcc_dir}"
+```
+
+This mirrors the CI configuration and prevents linker errors with `libstdc++`.
+
+### External APIs (optional)
+
+LLM (OpenAI-compatible) and TTS providers are configured at runtime through the app UI. They are not required for building, testing, or running the frontend. Without them, the app launches but AI chat responses won't work.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `AGENTS.md` with Cursor Cloud-specific development instructions for future agents working on this codebase.

### What's included

- Project layout overview (frontend, Tauri shell, core crate)
- Headless Cloud VM caveats (frontend-only mode via `npm run dev`)
- Lint, test, and build commands with references to CI
- Required Rust build environment variables for `whisper-rs-sys`
- Notes on optional external API dependencies

### Development environment verified

All checks pass:

| Check | Command | Result |
|---|---|---|
| Frontend tests | `npm test` | 38 passed |
| Frontend build | `npm run build` | Success |
| Rust format | `cargo fmt --all -- --check` | Clean |
| Rust lint | `cargo clippy --workspace --all-targets -- -D warnings` | Clean |
| Rust tests | `cargo test --workspace` | 55 passed |
| Dev server | `npm run dev` | Running on localhost:1420 |

### Demo

[meuxcompanion_onboarding_demo.mp4](https://cursor.com/agents/bc-9dfc9c06-33e5-489a-b2af-98efa6ab8da2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmeuxcompanion_onboarding_demo.mp4)

Frontend onboarding flow running in the browser via the Vite dev server.

[MeuxCompanion onboarding screen](https://cursor.com/agents/bc-9dfc9c06-33e5-489a-b2af-98efa6ab8da2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffrontend_onboarding.webp)
[Step 2 AI model configuration](https://cursor.com/agents/bc-9dfc9c06-33e5-489a-b2af-98efa6ab8da2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fstep2_ai_config.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9dfc9c06-33e5-489a-b2af-98efa6ab8da2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9dfc9c06-33e5-489a-b2af-98efa6ab8da2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

