### PR TITLE
⚡ Bolt: Prevent O(N) re-renders in chat history during text streaming

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -17,3 +17,7 @@
 ## 2024-05-18 - String Concatenation Overhead for Large Binary Arrays
 **Learning:** Appending characters one by one via `binary += String.fromCharCode(bytes[i])` for large TypedArrays (like audio PCM data) causes severe O(N^2) memory reallocation overhead because strings are immutable in JavaScript. For a 60-second audio clip, this can block the main thread for over 1.5 seconds.
 **Action:** Use a chunked approach with `String.fromCharCode.apply(null, chunk)` and a chunk size around `0x8000` to avoid Maximum Call Stack errors while significantly reducing string reallocation (e.g., dropping encoding time from 1.5s to 160ms).
+
+## 2026-10-30 - Defeated React.memo via Object Recreation in Maps
+**Learning:** When rendering list items, mapping a timeline object to a new object on every render (e.g. `const msg = timelineItemToMessage(item)`) and passing it as a prop defeats `React.memo`'s shallow comparison, causing components to re-render constantly (e.g. during rapid text streaming).
+**Action:** Always pass primitive values extracted from the generated object, or pass the original stable item directly to memoized child components to ensure `React.memo` behaves efficiently and prevents O(N) re-renders.

--- a/crates/meux-core/src/composio/catalog.rs
+++ b/crates/meux-core/src/composio/catalog.rs
@@ -6,8 +6,8 @@ use crate::error::{MeuxError, Result};
 use crate::tools::{PermissionLevel, ToolDefinition, ToolResult};
 
 use super::client::{
-    gmail_message_to_markdown, gmail_messages_to_markdown, gmail_threads_to_markdown,
-    tool_payload, value_string, ComposioClient,
+    gmail_message_to_markdown, gmail_messages_to_markdown, gmail_threads_to_markdown, tool_payload,
+    value_string, ComposioClient,
 };
 use super::tools::ComposioToolState;
 
@@ -68,15 +68,7 @@ pub fn permission_for_slug(slug: &str) -> PermissionLevel {
         "PERMANENTLY",
     ];
     const CAUTIOUS: &[&str] = &[
-        "CREATE",
-        "ADD_",
-        "UPDATE",
-        "PATCH",
-        "MODIFY",
-        "WRITE",
-        "SAVE",
-        "UPLOAD",
-        "INSERT",
+        "CREATE", "ADD_", "UPDATE", "PATCH", "MODIFY", "WRITE", "SAVE", "UPLOAD", "INSERT",
     ];
     if DANGEROUS.iter().any(|needle| upper.contains(needle)) {
         PermissionLevel::Dangerous
@@ -146,10 +138,14 @@ fn parse_tool_item(item: &Value, toolkit: &str) -> Option<ComposioCatalogEntry> 
     })
 }
 
-pub async fn build_catalog(state: &ComposioToolState) -> Result<HashMap<String, ComposioCatalogEntry>> {
-    let api_key = state.api_key.as_ref().filter(|k| !k.trim().is_empty()).ok_or_else(|| {
-        MeuxError::Tool("Composio API key is not configured.".to_string())
-    })?;
+pub async fn build_catalog(
+    state: &ComposioToolState,
+) -> Result<HashMap<String, ComposioCatalogEntry>> {
+    let api_key = state
+        .api_key
+        .as_ref()
+        .filter(|k| !k.trim().is_empty())
+        .ok_or_else(|| MeuxError::Tool("Composio API key is not configured.".to_string()))?;
     let client = ComposioClient::new(api_key.clone());
 
     let mut catalog = HashMap::new();

--- a/crates/meux-core/src/composio/client.rs
+++ b/crates/meux-core/src/composio/client.rs
@@ -13,6 +13,7 @@ pub const GMAIL_FETCH_TOOL: &str = "GMAIL_FETCH_EMAILS";
 
 pub struct ComposioClient {
     http: Client,
+    #[allow(dead_code)]
     api_key: String,
 }
 
@@ -132,11 +133,16 @@ impl ComposioClient {
             })?;
         let redirect_url = value_string(&response, &["redirect_url", "redirectUrl"])
             .ok_or_else(|| MeuxError::Llm("Composio did not return a redirect URL".to_string()))?;
-        let status = value_string(&response, &["status"]).unwrap_or_else(|| "initiated".to_string());
+        let status =
+            value_string(&response, &["status"]).unwrap_or_else(|| "initiated".to_string());
         Ok((connected_account_id, redirect_url, status))
     }
 
-    pub async fn list_tools_for_toolkit(&self, toolkit_slug: &str, limit: usize) -> Result<Vec<Value>> {
+    pub async fn list_tools_for_toolkit(
+        &self,
+        toolkit_slug: &str,
+        limit: usize,
+    ) -> Result<Vec<Value>> {
         let capped = limit.clamp(1, 100);
         let response = self
             .request_json(
@@ -200,7 +206,9 @@ impl ComposioClient {
             )
             .await?;
         if let Some(error) = tool_error(&response) {
-            return Err(MeuxError::Llm(format!("Composio proxy request failed: {error}")));
+            return Err(MeuxError::Llm(format!(
+                "Composio proxy request failed: {error}"
+            )));
         }
         Ok(response)
     }
@@ -314,9 +322,9 @@ pub fn extract_proxy_text(value: &Value) -> Result<String> {
             .and_then(Value::as_str)
             .is_some_and(|encoding| encoding.eq_ignore_ascii_case("base64"))
         {
-            let decoded = BASE64
-                .decode(content)
-                .map_err(|e| MeuxError::Tool(format!("Failed to decode base64 proxy content: {e}")))?;
+            let decoded = BASE64.decode(content).map_err(|e| {
+                MeuxError::Tool(format!("Failed to decode base64 proxy content: {e}"))
+            })?;
             return String::from_utf8(decoded)
                 .map_err(|e| MeuxError::Tool(format!("Proxy content was not valid UTF-8: {e}")));
         }

--- a/crates/meux-core/src/composio/tools.rs
+++ b/crates/meux-core/src/composio/tools.rs
@@ -4,8 +4,8 @@ use std::sync::{Arc, RwLock};
 use crate::composio_toolkits::default_enabled_toolkits;
 use crate::error::{MeuxError, Result};
 
-use super::client::{is_composio_connected, ComposioClient};
 use super::catalog::{build_catalog, ComposioCatalogEntry};
+use super::client::{is_composio_connected, ComposioClient};
 use crate::config::types::ComposioConnectionConfig;
 
 #[derive(Clone, Default)]
@@ -50,8 +50,14 @@ impl ComposioToolState {
     }
 }
 
-pub async fn refresh_catalog_for(state: &ComposioToolState) -> Result<HashMap<String, ComposioCatalogEntry>> {
-    if state.api_key.as_ref().is_none_or(|key| key.trim().is_empty()) {
+pub async fn refresh_catalog_for(
+    state: &ComposioToolState,
+) -> Result<HashMap<String, ComposioCatalogEntry>> {
+    if state
+        .api_key
+        .as_ref()
+        .is_none_or(|key| key.trim().is_empty())
+    {
         return Ok(HashMap::new());
     }
     let mut fetch_state = state.clone();
@@ -61,7 +67,11 @@ pub async fn refresh_catalog_for(state: &ComposioToolState) -> Result<HashMap<St
 }
 
 pub fn composio_tool_available(name: &str, state: &ComposioToolState) -> bool {
-    if state.api_key.as_ref().is_none_or(|key| key.trim().is_empty()) {
+    if state
+        .api_key
+        .as_ref()
+        .is_none_or(|key| key.trim().is_empty())
+    {
         return false;
     }
     state.catalog.contains_key(name)

--- a/crates/meux-core/src/llm/openai_compat.rs
+++ b/crates/meux-core/src/llm/openai_compat.rs
@@ -243,7 +243,10 @@ impl OpenAiCompatClient {
     /// List models from an OpenAI-compatible `GET /v1/models` endpoint.
     pub async fn list_models(&self, base_url: &str, api_key: &str) -> Result<Vec<String>> {
         let url = format!("{}/models", base_url.trim_end_matches('/'));
-        let mut request = self.client.get(&url).header("Content-Type", "application/json");
+        let mut request = self
+            .client
+            .get(&url)
+            .header("Content-Type", "application/json");
         if !api_key.is_empty() {
             request = request.header("Authorization", format!("Bearer {api_key}"));
         }

--- a/crates/meux-core/src/tools/mod.rs
+++ b/crates/meux-core/src/tools/mod.rs
@@ -101,11 +101,7 @@ impl ToolRegistry {
 
     /// Get all tool definitions.
     pub fn definitions(&self) -> Vec<ToolDefinition> {
-        let mut defs: Vec<ToolDefinition> = self
-            .tools
-            .values()
-            .map(|t| t.definition())
-            .collect();
+        let mut defs: Vec<ToolDefinition> = self.tools.values().map(|t| t.definition()).collect();
         for entry in self.composio_catalog_entries() {
             defs.push(entry.to_definition());
         }
@@ -116,11 +112,7 @@ impl ToolRegistry {
     /// Format tool definitions as the OpenAI `tools` array for the API request.
     /// Excludes tools listed in `disabled`.
     pub fn openai_tools_json_filtered(&self, disabled: &[String]) -> Vec<serde_json::Value> {
-        let composio = self
-            .composio_state
-            .read()
-            .ok()
-            .map(|state| state.clone());
+        let composio = self.composio_state.read().ok().map(|state| state.clone());
         self.openai_tools_json_filtered_with_composio(disabled, composio.as_ref())
     }
 
@@ -150,7 +142,11 @@ impl ToolRegistry {
             .collect();
 
         if let Some(state) = composio {
-            if state.api_key.as_ref().is_some_and(|key| !key.trim().is_empty()) {
+            if state
+                .api_key
+                .as_ref()
+                .is_some_and(|key| !key.trim().is_empty())
+            {
                 let mut composio_tools: Vec<_> = state.catalog.values().collect();
                 composio_tools.sort_by(|a, b| a.llm_name.cmp(&b.llm_name));
                 for entry in composio_tools {

--- a/src-tauri/src/commands/chat.rs
+++ b/src-tauri/src/commands/chat.rs
@@ -704,9 +704,7 @@ async fn run_chat_stream(
                         name,
                         arguments,
                     } => {
-                        println!(
-                            "[agent] tool call received: {name} id={id} args={arguments}"
-                        );
+                        println!("[agent] tool call received: {name} id={id} args={arguments}");
                         tool_calls.push((id, name, arguments));
                     }
 
@@ -781,9 +779,7 @@ async fn run_chat_stream(
 
         // If no tool calls, we're done
         if finish_reason != "tool_calls" || tool_calls.is_empty() {
-            println!(
-                "[agent] no tool calls, exiting loop after iteration {iteration}"
-            );
+            println!("[agent] no tool calls, exiting loop after iteration {iteration}");
             break;
         }
 

--- a/src-tauri/src/commands/chat.rs
+++ b/src-tauri/src/commands/chat.rs
@@ -317,7 +317,7 @@ fn spawn_tts_for_sentence(
                 let _ = app_tts.emit("chat:audio", AudioEvent { index, data: b64 });
             }
             Err(e) => {
-                eprintln!("TTS error for sentence {}: {}", index, e);
+                eprintln!("TTS error for sentence {index}: {e}");
             }
         }
     });
@@ -536,13 +536,15 @@ async fn run_chat_stream(
     } else {
         config.composio.enabled_toolkits.clone()
     };
-    state.tool_registry.update_composio_state(meux_core::composio::ComposioToolState {
-        api_key: config.composio.api_key.clone(),
-        user_id: user_id.clone(),
-        connections: config.composio.connections.clone(),
-        enabled_toolkits,
-        catalog: std::collections::HashMap::new(),
-    });
+    state
+        .tool_registry
+        .update_composio_state(meux_core::composio::ComposioToolState {
+            api_key: config.composio.api_key.clone(),
+            user_id: user_id.clone(),
+            connections: config.composio.connections.clone(),
+            enabled_toolkits,
+            catalog: std::collections::HashMap::new(),
+        });
     if let Err(err) = state.tool_registry.refresh_composio_catalog().await {
         eprintln!("[composio] failed to load tool catalog: {err}");
     }
@@ -567,7 +569,7 @@ async fn run_chat_stream(
 
     for iteration in 0..MAX_AGENT_ITERATIONS {
         if cancel.is_cancelled() {
-            println!("[agent] cancelled before iteration {}", iteration);
+            println!("[agent] cancelled before iteration {iteration}");
             return Ok(());
         }
 
@@ -631,7 +633,7 @@ async fn run_chat_stream(
                     Err(e) => {
                         let err_str = e.to_string();
                         if meux_core::retry::is_retryable_llm_error(&e) && stream_attempt < 5 {
-                            eprintln!("[agent] stream error (retryable): {}", err_str);
+                            eprintln!("[agent] stream error (retryable): {err_str}");
                             stream_error = true;
                             break;
                         }
@@ -703,8 +705,7 @@ async fn run_chat_stream(
                         arguments,
                     } => {
                         println!(
-                            "[agent] tool call received: {} id={} args={}",
-                            name, id, arguments
+                            "[agent] tool call received: {name} id={id} args={arguments}"
                         );
                         tool_calls.push((id, name, arguments));
                     }
@@ -781,8 +782,7 @@ async fn run_chat_stream(
         // If no tool calls, we're done
         if finish_reason != "tool_calls" || tool_calls.is_empty() {
             println!(
-                "[agent] no tool calls, exiting loop after iteration {}",
-                iteration
+                "[agent] no tool calls, exiting loop after iteration {iteration}"
             );
             break;
         }
@@ -845,8 +845,7 @@ async fn run_chat_stream(
                         {
                             Ok(result) => result,
                             Err(_) => Err(meux_core::MeuxError::Tool(format!(
-                                "{} timed out after 60s",
-                                tool_name
+                                "{tool_name} timed out after 60s"
                             ))),
                         }
                     }
@@ -860,7 +859,7 @@ async fn run_chat_stream(
                 let (tc_id, tc_name, args) = &safe_calls[i];
                 let (content, success) = match result {
                     Ok(tool_result) => (tool_result.content, tool_result.success),
-                    Err(e) => (format!("Tool error: {}", e), false),
+                    Err(e) => (format!("Tool error: {e}"), false),
                 };
 
                 let _ = app.emit(
@@ -895,7 +894,7 @@ async fn run_chat_stream(
                     request_id: tc_id.clone(),
                     tool_name: tc_name.clone(),
                     arguments: args.clone(),
-                    description: format!("Allow {} to execute?", tc_name),
+                    description: format!("Allow {tc_name} to execute?"),
                 },
             );
 
@@ -949,8 +948,8 @@ async fn run_chat_stream(
             .await;
             let (content, success) = match result {
                 Ok(Ok(tool_result)) => (tool_result.content, tool_result.success),
-                Ok(Err(e)) => (format!("Tool error: {}", e), false),
-                Err(_) => (format!("Tool {} timed out after 60s", tc_name), false),
+                Ok(Err(e)) => (format!("Tool error: {e}"), false),
+                Err(_) => (format!("Tool {tc_name} timed out after 60s"), false),
             };
 
             let _ = app.emit(

--- a/src-tauri/src/commands/config.rs
+++ b/src-tauri/src/commands/config.rs
@@ -1,6 +1,6 @@
 use crate::AppState;
-use meux_core::config::types::AppConfig;
 use meux_core::config::resolve_llm_api_key;
+use meux_core::config::types::AppConfig;
 use meux_core::llm::types::{ChatMessage, LlmStreamConfig};
 use meux_core::reset;
 use std::sync::Arc;
@@ -27,10 +27,7 @@ pub fn config_reset_all(state: State<Arc<AppState>>) -> Result<(), String> {
 
     reset::reset_app_data(&state.data_dir).map_err(|e| e.to_string())?;
     state.characters.clear_cache();
-    state
-        .config
-        .reset_to_default()
-        .map_err(|e| e.to_string())
+    state.config.reset_to_default().map_err(|e| e.to_string())
 }
 
 fn provider_fields(provider: &serde_json::Value) -> (String, String, Option<String>) {

--- a/src-tauri/src/commands/memory.rs
+++ b/src-tauri/src/commands/memory.rs
@@ -7,7 +7,6 @@ use meux_core::composio::{
 };
 use meux_core::composio_toolkits::{default_enabled_toolkits, toolkit_display_name};
 use meux_core::config::types::ComposioConnectionConfig;
-use serde_json::Value;
 use std::sync::Arc;
 use tauri::{AppHandle, Emitter, State};
 
@@ -438,7 +437,10 @@ pub async fn composio_authorize_toolkit(
     let user_id = get_user_id(&state);
     let api_key = composio_api_key(&state)?;
     let client = ComposioClient::new(api_key);
-    let auth_config_id = client.find_or_create_auth_config(&toolkit).await.map_err(|e| e.to_string())?;
+    let auth_config_id = client
+        .find_or_create_auth_config(&toolkit)
+        .await
+        .map_err(|e| e.to_string())?;
     let (connected_account_id, redirect_url, link_status) = client
         .link_toolkit(&user_id, &auth_config_id)
         .await
@@ -557,8 +559,9 @@ pub async fn composio_sync_github_readme(
         )
         .await
     {
-        Ok(tool_response) => extract_github_readme_markdown(&tool_response, None)
-            .map_err(|e| e.to_string())?,
+        Ok(tool_response) => {
+            extract_github_readme_markdown(&tool_response, None).map_err(|e| e.to_string())?
+        }
         Err(_) => {
             let proxy_response = client
                 .proxy_request(

--- a/src/components/ChatPanel.tsx
+++ b/src/components/ChatPanel.tsx
@@ -109,14 +109,21 @@ const MarkdownContent = memo(({ content }: { content: string }) => (
   </ReactMarkdown>
 ));
 
+// ⚡ Bolt: Destructuring props to primitives ensures React.memo's shallow comparison
+// works properly. Previously, passing a newly created `msg` object on every render
+// defeated memoization, causing O(N) re-renders of the chat history on every token.
 const MessageBubble = memo(function MessageBubble({
-  msg,
+  role,
+  text,
+  expression,
   characterName,
 }: {
-  msg: ChatMessage;
+  role: "user" | "assistant";
+  text: string;
+  expression?: string;
   characterName: string;
 }) {
-  const isUser = msg.role === "user";
+  const isUser = role === "user";
 
   return (
     <div className={`flex flex-col ${isUser ? "items-end" : "items-start"} animate-in fade-in slide-in-from-bottom-1 duration-200`}>
@@ -137,18 +144,18 @@ const MessageBubble = memo(function MessageBubble({
             <span className="text-[11px] text-blue-500 font-semibold tracking-wide uppercase">
               {characterName}
             </span>
-            {msg.expression && msg.expression !== "neutral" && (
+            {expression && expression !== "neutral" && (
               <span className="text-[10px] text-slate-400 font-normal capitalize bg-slate-50 px-2 py-0.5 rounded-full">
-                {msg.expression}
+                {expression}
               </span>
             )}
           </div>
         )}
         <div className={`text-[14px] leading-relaxed break-words ${isUser ? "text-white/95" : "text-slate-700"}`}>
           {isUser ? (
-            <p>{msg.text}</p>
+            <p>{text}</p>
           ) : (
-            <MarkdownContent content={msg.text} />
+            <MarkdownContent content={text} />
           )}
         </div>
       </div>
@@ -307,7 +314,15 @@ export function ChatPanel({
 
           const msg = timelineItemToMessage(item);
           if (!msg) return null;
-          return <MessageBubble key={item.id} msg={msg} characterName={characterName} />;
+          return (
+            <MessageBubble
+              key={item.id}
+              role={msg.role}
+              text={msg.text}
+              expression={msg.expression}
+              characterName={characterName}
+            />
+          );
         })}
 
         {/* Streaming text — always the latest assistant turn */}


### PR DESCRIPTION
💡 **What**: Refactored the `MessageBubble` component in `ChatPanel.tsx` to accept primitive props (`role`, `text`, `expression`) instead of an entire `msg` object.
🎯 **Why**: Previously, `timelineItemToMessage(item)` created a new `msg` object on every render. Passing this new object reference defeated `MessageBubble`'s `React.memo` shallow comparison, causing the entire chat history (which could contain dozens of messages) to completely re-render on every single token update when streaming a response.
📊 **Impact**: Reduces O(N) re-renders of the entire chat panel history down to O(1) (only the streaming message updates) during text generation, significantly improving UI smoothness and responsiveness.
🔬 **Measurement**: Verify using React Profiler during streaming text generation: observe that only the active message node re-renders, rather than all historical `MessageBubble` instances.

---
*PR created automatically by Jules for task [16980992611646227021](https://jules.google.com/task/16980992611646227021) started by @meet447*