### PR TITLE
⚡ Bolt: Prevent O(N) array operations in ChatPanel during text streaming

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -21,3 +21,6 @@
 ## 2026-10-30 - Defeated React.memo via Object Recreation in Maps
 **Learning:** When rendering list items, mapping a timeline object to a new object on every render (e.g. `const msg = timelineItemToMessage(item)`) and passing it as a prop defeats `React.memo`'s shallow comparison, causing components to re-render constantly (e.g. during rapid text streaming).
 **Action:** Always pass primitive values extracted from the generated object, or pass the original stable item directly to memoized child components to ensure `React.memo` behaves efficiently and prevents O(N) re-renders.
+## 2026-11-15 - React ChatPanel Array Re-creation during Streaming
+**Learning:** In a chat interface, text streaming causes rapid, continuous state updates (`streamingText`). If the render function performs O(N) array mapping or `Array.some()` checks over the full chat timeline without memoization, it wastes CPU cycles rebuilding elements and scanning arrays on every stream tick (~20-60 fps).
+**Action:** Always wrap full-list transformations (like `timeline.map(...)`) and full-list scanning checks (like `timeline.some(...)`) in a `useMemo` dependency array tracking the stable history array reference (`[timeline]`), isolating them from the high-frequency streaming text state.

--- a/src/components/ChatPanel.tsx
+++ b/src/components/ChatPanel.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect, useCallback, memo } from "react";
+import { useState, useRef, useEffect, useCallback, memo, useMemo } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import type { ChatMessage, ChatTimelineItem } from "../types";
@@ -281,9 +281,47 @@ export function ChatPanel({
   }, [timeline, streamingText]);
 
   const isProcessing = loading || ttsLoading;
-  const hasRunningTool = timeline.some(
-    (item) => item.kind === "tool" && item.call.status === "running",
+
+  // ⚡ Bolt: Memoize O(N) array checks to prevent recalculating on every streamingText update token
+  // Impact: Reduces CPU overhead during high-frequency text streaming by preventing O(N) array traversals
+  // Measurement: Eliminates redundant O(N) calls per token update (~20-30 frames per second during streaming)
+  const hasRunningTool = useMemo(
+    () => timeline.some((item) => item.kind === "tool" && item.call.status === "running"),
+    [timeline]
   );
+
+  const hasAnyTool = useMemo(
+    () => timeline.some((item) => item.kind === "tool"),
+    [timeline]
+  );
+
+  // ⚡ Bolt: Memoize the timeline mapping to prevent mapping O(N) items on every stream token
+  // Impact: Prevents recreating elements and array mapping during rapid streamingText updates
+  const renderedTimeline = useMemo(() => {
+    return timeline.map((item) => {
+      if (item.kind === "tool") {
+        return (
+          <ToolCallBubble
+            key={item.id}
+            call={item.call}
+            onConfirm={onToolConfirm}
+          />
+        );
+      }
+
+      const msg = timelineItemToMessage(item);
+      if (!msg) return null;
+      return (
+        <MessageBubble
+          key={item.id}
+          role={msg.role}
+          text={msg.text}
+          expression={msg.expression}
+          characterName={characterName}
+        />
+      );
+    });
+  }, [timeline, characterName, onToolConfirm]);
 
   return (
     <div className="flex-1 flex flex-col bg-transparent relative h-full">
@@ -301,29 +339,7 @@ export function ChatPanel({
           </div>
         )}
 
-        {timeline.map((item) => {
-          if (item.kind === "tool") {
-            return (
-              <ToolCallBubble
-                key={item.id}
-                call={item.call}
-                onConfirm={onToolConfirm}
-              />
-            );
-          }
-
-          const msg = timelineItemToMessage(item);
-          if (!msg) return null;
-          return (
-            <MessageBubble
-              key={item.id}
-              role={msg.role}
-              text={msg.text}
-              expression={msg.expression}
-              characterName={characterName}
-            />
-          );
-        })}
+        {renderedTimeline}
 
         {/* Streaming text — always the latest assistant turn */}
         {streamingText && (
@@ -357,7 +373,7 @@ export function ChatPanel({
                   <span className="w-2 h-2 rounded-full bg-blue-400/60 animate-bounce" />
                 </div>
                 <span className="text-xs font-semibold uppercase tracking-wide">
-                  {timeline.some((item) => item.kind === "tool") ? "Continuing" : "Thinking"}
+                  {hasAnyTool ? "Continuing" : "Thinking"}
                 </span>
               </div>
             </div>


### PR DESCRIPTION
💡 What: Wrapped `timeline.map()` and `timeline.some()` operations inside `ChatPanel.tsx` in `useMemo` hooks with a dependency array on the stable `timeline` reference.

🎯 Why: During text streaming (`streamingText`), state updates trigger a re-render of `ChatPanel` every single token update (~20-60 frames per second). Without memoization, `ChatPanel` was unnecessarily executing O(N) array traversals (mapping historical items into elements and checking for tool statuses) on every stream tick, wasting CPU cycles and garbage collection overhead.

📊 Impact: Reduces CPU and memory reallocation overhead during active message streaming by converting O(N) array traversals per stream tick to O(1) reads of the memoized output.

🔬 Measurement: Verifiable using React DevTools profiler to measure the render cost of `ChatPanel` during a long streamed response, which will show negligible re-render time compared to previously un-memoized arrays being recreated on every keystroke/token.

---
*PR created automatically by Jules for task [4113353129162288352](https://jules.google.com/task/4113353129162288352) started by @meet447*