### PR TITLE
⚡ Bolt: Memoize O(N) array operations during text streaming

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -21,3 +21,7 @@
 ## 2026-10-30 - Defeated React.memo via Object Recreation in Maps
 **Learning:** When rendering list items, mapping a timeline object to a new object on every render (e.g. `const msg = timelineItemToMessage(item)`) and passing it as a prop defeats `React.memo`'s shallow comparison, causing components to re-render constantly (e.g. during rapid text streaming).
 **Action:** Always pass primitive values extracted from the generated object, or pass the original stable item directly to memoized child components to ensure `React.memo` behaves efficiently and prevents O(N) re-renders.
+
+## 2026-10-31 - Memoize Array Iterations During Text Streaming
+**Learning:** During rapid text streaming (e.g. updating the latest message token by token), checking conditions on the entire chat history (like `timeline.some(...)` to check for active tools) or re-mapping the entire `timeline` into React components on every single render cycle causes an O(N) performance bottleneck.
+**Action:** Extract expensive `Array.prototype` methods (like `.some()`, `.map()`) out of the JSX render body and wrap them in `useMemo` hooks keyed to the array reference (e.g., `[timeline]`). This ensures the operations are only performed when the array reference actually changes, preventing unnecessary O(N) traversals on every text update.

--- a/src/components/ChatPanel.tsx
+++ b/src/components/ChatPanel.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect, useCallback, memo } from "react";
+import { useState, useRef, useEffect, useCallback, memo, useMemo } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import type { ChatMessage, ChatTimelineItem } from "../types";
@@ -281,9 +281,43 @@ export function ChatPanel({
   }, [timeline, streamingText]);
 
   const isProcessing = loading || ttsLoading;
-  const hasRunningTool = timeline.some(
-    (item) => item.kind === "tool" && item.call.status === "running",
+  // ⚡ Bolt: Wrap O(N) array operations in useMemo keyed to the timeline reference.
+  // This prevents traversing the entire chat history on every single text streaming update.
+  const hasRunningTool = useMemo(
+    () => timeline.some((item) => item.kind === "tool" && item.call.status === "running"),
+    [timeline]
   );
+
+  const hasAnyTool = useMemo(
+    () => timeline.some((item) => item.kind === "tool"),
+    [timeline]
+  );
+
+  const memoizedTimeline = useMemo(() => {
+    return timeline.map((item) => {
+      if (item.kind === "tool") {
+        return (
+          <ToolCallBubble
+            key={item.id}
+            call={item.call}
+            onConfirm={onToolConfirm}
+          />
+        );
+      }
+
+      const msg = timelineItemToMessage(item);
+      if (!msg) return null;
+      return (
+        <MessageBubble
+          key={item.id}
+          role={msg.role}
+          text={msg.text}
+          expression={msg.expression}
+          characterName={characterName}
+        />
+      );
+    });
+  }, [timeline, characterName, onToolConfirm]);
 
   return (
     <div className="flex-1 flex flex-col bg-transparent relative h-full">
@@ -301,29 +335,7 @@ export function ChatPanel({
           </div>
         )}
 
-        {timeline.map((item) => {
-          if (item.kind === "tool") {
-            return (
-              <ToolCallBubble
-                key={item.id}
-                call={item.call}
-                onConfirm={onToolConfirm}
-              />
-            );
-          }
-
-          const msg = timelineItemToMessage(item);
-          if (!msg) return null;
-          return (
-            <MessageBubble
-              key={item.id}
-              role={msg.role}
-              text={msg.text}
-              expression={msg.expression}
-              characterName={characterName}
-            />
-          );
-        })}
+        {memoizedTimeline}
 
         {/* Streaming text — always the latest assistant turn */}
         {streamingText && (
@@ -357,7 +369,7 @@ export function ChatPanel({
                   <span className="w-2 h-2 rounded-full bg-blue-400/60 animate-bounce" />
                 </div>
                 <span className="text-xs font-semibold uppercase tracking-wide">
-                  {timeline.some((item) => item.kind === "tool") ? "Continuing" : "Thinking"}
+                  {hasAnyTool ? "Continuing" : "Thinking"}
                 </span>
               </div>
             </div>


### PR DESCRIPTION
💡 What: Extracted inline `timeline.some` and `timeline.map` operations into `useMemo` hooks in `ChatPanel.tsx`.

🎯 Why: During rapid text streaming, evaluating O(N) array operations on every render cycle causes a performance bottleneck and blocks the main thread, leading to jittery text rendering.

📊 Impact: Significantly reduces the number of operations performed during rapid text streaming (from O(N) per token to O(1) per token), preventing unnecessary array traversals and React element recreations.

🔬 Measurement: Profile the application during an active LLM text stream. Observe that the time spent in `ChatPanel` render is drastically reduced, as the `hasRunningTool`, `hasAnyTool`, and `memoizedTimeline` variables are pulled from the memoized cache rather than re-computed on every text update.

---
*PR created automatically by Jules for task [8750392324650307503](https://jules.google.com/task/8750392324650307503) started by @meet447*