### PR TITLE
Fix VRM model detection and rendering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1845,6 +1845,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-range"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21dec9db110f5f872ed9699c3ecf50cf16f423502706ba5c72462e28d3157573"
+
+[[package]]
 name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4414,6 +4420,7 @@ dependencies = [
  "gtk",
  "heck 0.5.0",
  "http",
+ "http-range",
  "jni",
  "libc",
  "log",

--- a/crates/meux-core/src/character/mod.rs
+++ b/crates/meux-core/src/character/mod.rs
@@ -366,7 +366,7 @@ fn load_from_directory(id: &str, dir: &Path) -> Result<Character> {
     let yaml: CharacterYaml = serde_yaml::from_str(&raw)?;
 
     let name = yaml.name.unwrap_or_else(|| id.to_string());
-    let live2d_model = yaml.live2d_model.unwrap_or_default();
+    let live2d_model = yaml.live2d_model.or(yaml.vrm_model).unwrap_or_default();
     let voice = yaml.voice.unwrap_or_default();
     let default_emotion = yaml
         .default_emotion
@@ -411,7 +411,7 @@ fn load_from_markdown(id: &str, path: &Path) -> Result<Character> {
     let yaml: CharacterYaml = serde_yaml::from_str(&frontmatter)?;
 
     let name = yaml.name.unwrap_or_else(|| id.to_string());
-    let live2d_model = yaml.live2d_model.unwrap_or_default();
+    let live2d_model = yaml.live2d_model.or(yaml.vrm_model).unwrap_or_default();
     let voice = yaml.voice.unwrap_or_default();
     let default_emotion = yaml
         .default_emotion
@@ -530,30 +530,55 @@ fn build_prompt_sections_body(name: &str, sections: &PromptSections) -> String {
 /// List available Live2D and VRM models on disk.
 pub fn list_models(data_dir: &Path) -> Result<Vec<ModelInfo>> {
     let mut models = Vec::new();
-    let models_dir = data_dir.join("models");
+    let mut seen = std::collections::HashSet::new();
 
-    // Scan live2d models
+    let mut scan_roots = vec![data_dir.join("models")];
+    for fallback in [PathBuf::from("models"), PathBuf::from("../models")] {
+        if fallback.exists() {
+            scan_roots.push(fallback);
+        }
+    }
+
+    for models_dir in scan_roots {
+        scan_models_dir(&models_dir, &mut models, &mut seen);
+    }
+
+    models.sort_by(|a, b| a.id.cmp(&b.id));
+    Ok(models)
+}
+
+fn scan_models_dir(
+    models_dir: &Path,
+    models: &mut Vec<ModelInfo>,
+    seen: &mut std::collections::HashSet<(String, String)>,
+) {
     let live2d_dir = models_dir.join("live2d");
     if live2d_dir.exists() {
         if let Ok(entries) = fs::read_dir(&live2d_dir) {
             for entry in entries.flatten() {
                 let path = entry.path();
-                if path.is_dir() {
-                    let id = path.file_name().unwrap().to_string_lossy().to_string();
-                    let model_file =
-                        find_model3_json(&path).unwrap_or_else(|| format!("{id}.model3.json"));
-                    models.push(ModelInfo {
-                        id: id.clone(),
-                        model_type: "live2d".to_string(),
-                        model_file: model_file.clone(),
-                        path: format!("models/live2d/{id}/{model_file}"),
-                    });
+                if !path.is_dir() {
+                    continue;
                 }
+                let id = path.file_name().unwrap().to_string_lossy().to_string();
+                let key = (id.clone(), "live2d".to_string());
+                if seen.contains(&key) {
+                    continue;
+                }
+                let Some(model_file) = find_model3_json(&path) else {
+                    continue;
+                };
+                seen.insert(key);
+                models.push(ModelInfo {
+                    id: id.clone(),
+                    model_type: "live2d".to_string(),
+                    model_file: model_file.clone(),
+                    path: format!("models/live2d/{id}/{model_file}"),
+                });
             }
         }
     }
 
-    // Scan vrm models
     let vrm_dir = models_dir.join("vrm");
     if vrm_dir.exists() {
         if let Ok(entries) = fs::read_dir(&vrm_dir) {
@@ -561,15 +586,28 @@ pub fn list_models(data_dir: &Path) -> Result<Vec<ModelInfo>> {
                 let path = entry.path();
                 if path.is_dir() {
                     let id = path.file_name().unwrap().to_string_lossy().to_string();
+                    let key = (id.clone(), "vrm".to_string());
+                    if seen.contains(&key) {
+                        continue;
+                    }
+                    let Some(model_file) = find_vrm_file(&path) else {
+                        continue;
+                    };
+                    seen.insert(key);
                     models.push(ModelInfo {
                         id: id.clone(),
                         model_type: "vrm".to_string(),
-                        model_file: "model.vrm".to_string(),
-                        path: format!("models/vrm/{id}/model.vrm"),
+                        model_file: model_file.clone(),
+                        path: format!("models/vrm/{id}/{model_file}"),
                     });
-                } else if path.extension().is_some_and(|e| e == "vrm") {
+                } else if is_vrm_extension(path.extension()) {
                     let id = path.file_stem().unwrap().to_string_lossy().to_string();
                     let fname = path.file_name().unwrap().to_string_lossy().to_string();
+                    let key = (id.clone(), "vrm".to_string());
+                    if seen.contains(&key) {
+                        continue;
+                    }
+                    seen.insert(key);
                     models.push(ModelInfo {
                         id: id.clone(),
                         model_type: "vrm".to_string(),
@@ -580,9 +618,6 @@ pub fn list_models(data_dir: &Path) -> Result<Vec<ModelInfo>> {
             }
         }
     }
-
-    models.sort_by(|a, b| a.id.cmp(&b.id));
-    Ok(models)
 }
 
 /// Read the available expression names from a Live2D model's model3.json file
@@ -618,12 +653,8 @@ pub fn get_model_expressions(data_dir: &Path, model_id: &str) -> Result<Vec<Stri
 
     // Try VRM
     let vrm_dir = models_dir.join("vrm").join(model_id);
-    if vrm_dir.exists()
-        || models_dir
-            .join("vrm")
-            .join(format!("{model_id}.vrm"))
-            .exists()
-    {
+    let flat_vrm = models_dir.join("vrm").join(format!("{model_id}.vrm"));
+    if (vrm_dir.exists() && find_vrm_file(&vrm_dir).is_some()) || flat_vrm.exists() {
         // VRM models have standard blend shape expressions
         return Ok(vec![
             "happy".to_string(),
@@ -635,6 +666,23 @@ pub fn get_model_expressions(data_dir: &Path, model_id: &str) -> Result<Vec<Stri
     }
 
     Ok(Vec::new())
+}
+
+fn is_vrm_extension(ext: Option<&std::ffi::OsStr>) -> bool {
+    ext.and_then(|value| value.to_str())
+        .is_some_and(|value| value.eq_ignore_ascii_case("vrm"))
+}
+
+fn find_vrm_file(dir: &Path) -> Option<String> {
+    if let Ok(entries) = fs::read_dir(dir) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_file() && is_vrm_extension(path.extension()) {
+                return Some(path.file_name().unwrap().to_string_lossy().to_string());
+            }
+        }
+    }
+    None
 }
 
 fn find_model3_json(dir: &Path) -> Option<String> {
@@ -776,5 +824,61 @@ mod tests {
         assert!(fm.contains("name: Luna"));
         assert!(fm.contains("voice: en-GB"));
         assert!(body.contains("Body content here."));
+    }
+
+    #[test]
+    fn test_list_vrm_models_detects_various_layouts() {
+        let tmp = TempDir::new().unwrap();
+        let models_root = tmp.path().join("models").join("vrm");
+        fs::create_dir_all(models_root.join("imported")).unwrap();
+        fs::write(models_root.join("imported/model.vrm"), b"vrm").unwrap();
+
+        fs::create_dir_all(models_root.join("custom_name")).unwrap();
+        fs::write(models_root.join("custom_name/avatar.vrm"), b"vrm").unwrap();
+
+        fs::write(models_root.join("flat_model.vrm"), b"vrm").unwrap();
+
+        let models = list_models(tmp.path()).unwrap();
+        let vrm_ids: Vec<&str> = models
+            .iter()
+            .filter(|model| model.model_type == "vrm")
+            .map(|model| model.id.as_str())
+            .collect();
+
+        assert_eq!(vrm_ids, vec!["custom_name", "flat_model", "imported"]);
+        assert_eq!(
+            models
+                .iter()
+                .find(|model| model.id == "custom_name")
+                .map(|model| model.model_file.as_str()),
+            Some("avatar.vrm")
+        );
+    }
+
+    #[test]
+    fn test_list_vrm_ignores_empty_directories() {
+        let tmp = TempDir::new().unwrap();
+        let models_root = tmp.path().join("models").join("vrm");
+        fs::create_dir_all(models_root.join("empty_folder")).unwrap();
+
+        let models = list_models(tmp.path()).unwrap();
+        assert!(models.iter().all(|model| model.model_type != "vrm"));
+    }
+
+    #[test]
+    fn test_load_character_uses_vrm_model_field() {
+        let tmp = TempDir::new().unwrap();
+        let loader = CharacterLoader::new(tmp.path());
+        let char_dir = tmp.path().join("characters").join("luna");
+        fs::create_dir_all(&char_dir).unwrap();
+        fs::write(
+            char_dir.join("character.yaml"),
+            "name: Luna\nvrm_model: my_avatar\nvoice: en-GB-1\ndefault_emotion: happy\n",
+        )
+        .unwrap();
+        fs::write(char_dir.join("soul.md"), "Soul").unwrap();
+
+        let character = loader.load_character("luna").unwrap();
+        assert_eq!(character.live2d_model, "my_avatar");
     }
 }

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 tauri-build = { version = "2", features = [] }
 
 [dependencies]
-tauri = { version = "2", features = ["macos-private-api", "tray-icon"] }
+tauri = { version = "2", features = ["protocol-asset", "macos-private-api", "tray-icon"] }
 tauri-plugin-shell = "2"
 tauri-plugin-global-shortcut = "2"
 tauri-plugin-autostart = "2"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -48,12 +48,19 @@ fn get_data_dir(state: tauri::State<Arc<AppState>>) -> String {
 #[tauri::command]
 fn resolve_asset_path(state: tauri::State<Arc<AppState>>, path: String) -> Result<String, String> {
     let clean = path.trim_start_matches('/');
-    let full_path = state.data_dir.join(clean);
-    if full_path.exists() {
-        Ok(full_path.to_string_lossy().to_string())
-    } else {
-        Err(format!("Asset not found: {}", full_path.display()))
+    let candidates = [
+        state.data_dir.join(clean),
+        PathBuf::from(clean),
+        PathBuf::from("..").join(clean),
+    ];
+
+    for full_path in candidates {
+        if full_path.exists() && full_path.is_file() {
+            return Ok(full_path.to_string_lossy().to_string());
+        }
     }
+
+    Err(format!("Asset not found: {clean}"))
 }
 
 fn load_whisper_model(data_dir: &Path) -> Option<Arc<WhisperContext>> {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -22,7 +22,18 @@
       }
     ],
     "security": {
-      "csp": null
+      "csp": null,
+      "assetProtocol": {
+        "enable": true,
+        "scope": {
+          "allow": [
+            "$APPDATA/**",
+            "$APPLOCALDATA/**",
+            "$RESOURCE/**"
+          ],
+          "requireLiteralLeadingDot": false
+        }
+      }
     },
     "macOSPrivateApi": true
   },

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,7 +19,7 @@ import {
   getModelExpressions,
   getChatHistory,
   clearChat,
-  toAssetUrl,
+  resolveAssetUrl,
 } from "./api/tauri";
 import type { Character, ModelInfo } from "./types";
 
@@ -253,8 +253,35 @@ function App() {
     return models.find((m) => m.id === selectedChar.live2d_model) ?? null;
   }, [selectedChar, models]);
 
-  const modelPath = selectedModel?.path ? toAssetUrl(selectedModel.path) : null;
-  const modelType = selectedModel?.type ?? "live2d";
+  const [resolvedModelPath, setResolvedModelPath] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!selectedModel?.path) {
+      setResolvedModelPath(null);
+      return;
+    }
+
+    let cancelled = false;
+    resolveAssetUrl(selectedModel.path)
+      .then((url) => {
+        if (!cancelled) {
+          setResolvedModelPath(url);
+        }
+      })
+      .catch((err) => {
+        console.error("[App] Failed to resolve model asset URL:", err);
+        if (!cancelled) {
+          setResolvedModelPath(null);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [selectedModel?.path]);
+
+  const modelPath = resolvedModelPath;
+  const modelType = selectedModel?.type === "vrm" ? "vrm" : "live2d";
   const modelMapping = selectedModel?.mapping ?? null;
 
   // Match chat backend: expression files are keyed by character.live2d_model.

--- a/src/api/tauri.test.ts
+++ b/src/api/tauri.test.ts
@@ -5,6 +5,7 @@ import * as tauriApi from './tauri';
 // Mock the invoke function from @tauri-apps/api/core
 vi.mock('@tauri-apps/api/core', () => ({
   invoke: vi.fn(),
+  convertFileSrc: vi.fn((filePath: string) => `asset://localhost/${encodeURIComponent(filePath)}`),
 }));
 
 describe('tauri api utilities', () => {
@@ -17,6 +18,44 @@ describe('tauri api utilities', () => {
       expect(tauriApi.toAssetUrl('/my-asset.png')).toBe('/static/my-asset.png');
       expect(tauriApi.toAssetUrl('my-asset.png')).toBe('/static/my-asset.png');
       expect(tauriApi.toAssetUrl('///deep/path.png')).toBe('/static/deep/path.png');
+    });
+  });
+
+  describe('resolveAssetUrl', () => {
+    it('uses convertFileSrc for files inside app data', async () => {
+      vi.mocked(invoke).mockImplementation(async (command: string) => {
+        if (command === 'resolve_asset_path') {
+          return '/data/com.meuxcompanion.app/models/vrm/demo/model.vrm';
+        }
+        if (command === 'get_data_dir') {
+          return '/data/com.meuxcompanion.app';
+        }
+        return null;
+      });
+
+      const url = await tauriApi.resolveAssetUrl('models/vrm/demo/model.vrm');
+      expect(url).toContain('asset://localhost');
+    });
+
+    it('falls back to /static/ for files outside app data', async () => {
+      vi.mocked(invoke).mockImplementation(async (command: string) => {
+        if (command === 'resolve_asset_path') {
+          return '/workspace/models/vrm/demo/model.vrm';
+        }
+        if (command === 'get_data_dir') {
+          return '/data/com.meuxcompanion.app';
+        }
+        return null;
+      });
+
+      const url = await tauriApi.resolveAssetUrl('models/vrm/demo/model.vrm');
+      expect(url).toBe('/static/models/vrm/demo/model.vrm');
+    });
+
+    it('falls back to /static/ when resolve_asset_path fails', async () => {
+      vi.mocked(invoke).mockRejectedValueOnce(new Error('missing'));
+      const url = await tauriApi.resolveAssetUrl('models/vrm/demo/model.vrm');
+      expect(url).toBe('/static/models/vrm/demo/model.vrm');
     });
   });
 

--- a/src/api/tauri.ts
+++ b/src/api/tauri.ts
@@ -1,11 +1,30 @@
-import { invoke } from "@tauri-apps/api/core";
+import { invoke, convertFileSrc } from "@tauri-apps/api/core";
 
-// Asset paths — serves files from app data directory
-// In dev mode: Vite middleware serves from /static/
-// In production: TODO — use Tauri asset protocol or embed
+// Asset paths — in the Tauri app, resolve to convertFileSrc URLs via the backend.
+// In browser-only dev (npm run dev), fall back to Vite /static/ middleware.
 export function toAssetUrl(relativePath: string): string {
   const clean = relativePath.replace(/^\/+/, "");
   return `/static/${clean}`;
+}
+
+export async function resolveAssetUrl(relativePath: string): Promise<string> {
+  const clean = relativePath.replace(/^\/+/, "");
+  try {
+    const [absolutePath, dataDir] = await Promise.all([
+      invoke<string>("resolve_asset_path", { path: clean }),
+      invoke<string>("get_data_dir"),
+    ]);
+    const normalizedDataDir = dataDir.replace(/\\/g, "/").replace(/\/$/, "");
+    const normalizedAbsolute = absolutePath.replace(/\\/g, "/");
+    if (normalizedAbsolute.startsWith(`${normalizedDataDir}/`)) {
+      return convertFileSrc(absolutePath);
+    }
+    console.warn("[assets] Model is outside app data; using /static/ fallback:", clean);
+    return toAssetUrl(clean);
+  } catch (err) {
+    console.warn("[assets] Falling back to /static/ URL for", clean, err);
+    return toAssetUrl(clean);
+  }
 }
 
 // Config

--- a/src/components/VRMCanvas.tsx
+++ b/src/components/VRMCanvas.tsx
@@ -154,6 +154,9 @@ export const VRMCanvas = memo(function VRMCanvas({
             <button onClick={() => setShowDebug(false)} className="text-slate-400 hover:text-slate-600 ml-4 hover:bg-slate-100 rounded-full w-5 h-5 flex items-center justify-center transition-colors">x</button>
           </div>
           <Row label="Model" value={debugInfo.modelLoaded ? "loaded (VRM)" : "none"} ok={debugInfo.modelLoaded} />
+          {!debugInfo.modelLoaded && debugInfo.lastError ? (
+            <Row label="Load Error" value={debugInfo.lastError} />
+          ) : null}
           <Row label="Lip Sync" value={debugInfo.lipSyncActive ? "ON" : "off"} ok={debugInfo.lipSyncActive} />
           <Row label="Mouth Value" value={String(debugInfo.mouthValue)} />
           <div className="pt-1">

--- a/src/hooks/useVRM.ts
+++ b/src/hooks/useVRM.ts
@@ -37,6 +37,7 @@ export function useVRM(canvasRef: React.RefObject<HTMLCanvasElement | null>) {
   // Debug cache
   const availableExpressionsRef = useRef<string[]>([]);
   const availableMotionGroupsRef = useRef<string[]>([]);
+  const lastErrorRef = useRef("");
 
   // Blinking
   const lastBlinkTimeRef = useRef(Date.now());
@@ -304,6 +305,7 @@ export function useVRM(canvasRef: React.RefObject<HTMLCanvasElement | null>) {
         animFrameRef.current = 0;
       }
 
+      lastErrorRef.current = "";
       // Clean up previous
       if (vrmRef.current) {
         vrmRef.current.scene.removeFromParent();
@@ -435,6 +437,7 @@ export function useVRM(canvasRef: React.RefObject<HTMLCanvasElement | null>) {
 
         startAnimationLoop();
       } catch (err) {
+        lastErrorRef.current = err instanceof Error ? err.message : String(err);
         console.error("[VRM] Failed to load model:", err);
       }
     },
@@ -552,7 +555,7 @@ export function useVRM(canvasRef: React.RefObject<HTMLCanvasElement | null>) {
     mappingEmotions: [],
     availableExpressions: availableExpressionsRef.current,
     availableMotionGroups: availableMotionGroupsRef.current,
-    lastError: "",
+    lastError: lastErrorRef.current,
   }), []);
 
   return {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -24,44 +24,57 @@ function resolveAppDataDir() {
 
 function appDataStaticPlugin() {
   const appDataDir = resolveAppDataDir();
+  const workspaceRoot = process.cwd();
+
+  const serveFile = (filePath: string, req: any, res: any) => {
+    const stat = fs.statSync(filePath);
+    const ext = path.extname(filePath).toLowerCase();
+    const mimeTypes: Record<string, string> = {
+      ".json": "application/json",
+      ".moc3": "application/octet-stream",
+      ".png": "image/png",
+      ".jpg": "image/jpeg",
+      ".jpeg": "image/jpeg",
+      ".mp3": "audio/mpeg",
+      ".vrm": "application/octet-stream",
+      ".glb": "application/octet-stream",
+      ".gltf": "application/json",
+      ".fbx": "application/octet-stream",
+    };
+    res.setHeader("Content-Type", mimeTypes[ext] || "application/octet-stream");
+    res.setHeader("Content-Length", stat.size);
+    res.setHeader("Access-Control-Allow-Origin", "*");
+    res.setHeader("Access-Control-Allow-Methods", "GET, OPTIONS");
+    res.setHeader("Access-Control-Allow-Headers", "*");
+    res.setHeader("Cache-Control", "no-cache");
+    if (req.method === "OPTIONS") {
+      res.statusCode = 204;
+      res.end();
+      return;
+    }
+    fs.createReadStream(filePath).pipe(res);
+  };
 
   return {
     name: "serve-appdata",
     configureServer(server: any) {
       server.middlewares.use("/static", (req: any, res: any, next: any) => {
-        // Strip query string from URL before resolving file path
         const urlPath = (req.url || "").split("?")[0];
-        const filePath = path.join(appDataDir, decodeURIComponent(urlPath));
-        if (fs.existsSync(filePath) && fs.statSync(filePath).isFile()) {
-          const stat = fs.statSync(filePath);
-          const ext = path.extname(filePath).toLowerCase();
-          const mimeTypes: Record<string, string> = {
-            ".json": "application/json",
-            ".moc3": "application/octet-stream",
-            ".png": "image/png",
-            ".jpg": "image/jpeg",
-            ".jpeg": "image/jpeg",
-            ".mp3": "audio/mpeg",
-            ".vrm": "application/octet-stream",
-            ".glb": "application/octet-stream",
-            ".gltf": "application/json",
-            ".fbx": "application/octet-stream",
-          };
-          res.setHeader("Content-Type", mimeTypes[ext] || "application/octet-stream");
-          res.setHeader("Content-Length", stat.size);
-          res.setHeader("Access-Control-Allow-Origin", "*");
-          res.setHeader("Access-Control-Allow-Methods", "GET, OPTIONS");
-          res.setHeader("Access-Control-Allow-Headers", "*");
-          res.setHeader("Cache-Control", "no-cache");
-          if (req.method === "OPTIONS") {
-            res.statusCode = 204;
-            res.end();
+        const decoded = decodeURIComponent(urlPath);
+        const candidates = [
+          path.join(appDataDir, decoded),
+          path.join(workspaceRoot, decoded),
+          path.join(workspaceRoot, "..", decoded),
+        ];
+
+        for (const filePath of candidates) {
+          if (fs.existsSync(filePath) && fs.statSync(filePath).isFile()) {
+            serveFile(filePath, req, res);
             return;
           }
-          fs.createReadStream(filePath).pipe(res);
-        } else {
-          next();
         }
+
+        next();
       });
     },
   };

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,11 +8,22 @@ import { homedir } from "os";
 const host = process.env.TAURI_DEV_HOST;
 
 // Serve files from app data directory under /static/ path in dev mode
+function resolveAppDataDir() {
+  const home = homedir();
+  if (process.platform === "darwin") {
+    return path.join(home, "Library/Application Support/com.meuxcompanion.app");
+  }
+  if (process.platform === "win32") {
+    return path.join(
+      process.env.APPDATA || path.join(home, "AppData", "Roaming"),
+      "com.meuxcompanion.app",
+    );
+  }
+  return path.join(home, ".local/share/com.meuxcompanion.app");
+}
+
 function appDataStaticPlugin() {
-  const appDataDir = path.join(
-    homedir(),
-    "Library/Application Support/com.meuxcompanion.app"
-  );
+  const appDataDir = resolveAppDataDir();
 
   return {
     name: "serve-appdata",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes VRM avatars appearing in the model picker but not rendering in the app (debug panel showed **Model: none**).

## Changes

### Detection
- Scan VRM folders for **any** `.vrm` file (case-insensitive), not only `model.vrm`
- Skip empty directories without a VRM file
- Fall back to repo `models/` directory when scanning (matches README layout)
- Honor `vrm_model` in `character.yaml` when `live2d_model` is unset

### Rendering
- Add `resolveAssetUrl()` to resolve model files via Tauri `resolve_asset_path` + `convertFileSrc` for app-data assets
- Enable Tauri `assetProtocol` in `tauri.conf.json` and the `protocol-asset` crate feature
- Fall back to Vite `/static/` for repo-bundled models during dev
- Expand Vite `/static/` middleware to also serve workspace `models/`
- Show VRM load errors in the debug overlay

## Testing

- `cargo test -p meux-core character::tests`
- `npm test` (includes `resolveAssetUrl` tests)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d75575a1-702a-4b1e-9be5-67a2b86d6a19"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d75575a1-702a-4b1e-9be5-67a2b86d6a19"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

