### PR TITLE
⚡ Bolt: Memoize O(N) timeline operations in ChatPanel

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -21,3 +21,7 @@
 ## 2026-10-30 - Defeated React.memo via Object Recreation in Maps
 **Learning:** When rendering list items, mapping a timeline object to a new object on every render (e.g. `const msg = timelineItemToMessage(item)`) and passing it as a prop defeats `React.memo`'s shallow comparison, causing components to re-render constantly (e.g. during rapid text streaming).
 **Action:** Always pass primitive values extracted from the generated object, or pass the original stable item directly to memoized child components to ensure `React.memo` behaves efficiently and prevents O(N) re-renders.
+
+## 2026-10-31 - React List Re-renders from Array methods in Render
+**Learning:** Performing array mapping (like `timeline.map`) and array searches (like `timeline.some`) directly inside the render loop of a parent component (like `ChatPanel.tsx`) causes O(N) operations to execute on every single re-render, such as when rapidly streaming text.
+**Action:** Wrap computationally expensive array generation and searching in `useMemo` hooks keyed to the array reference (e.g. `[timeline]`) to prevent unnecessary N operations on every single token streaming update.

--- a/src/components/ChatPanel.tsx
+++ b/src/components/ChatPanel.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect, useCallback, memo } from "react";
+import { useState, useRef, useEffect, useCallback, useMemo, memo } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import type { ChatMessage, ChatTimelineItem } from "../types";
@@ -281,9 +281,38 @@ export function ChatPanel({
   }, [timeline, streamingText]);
 
   const isProcessing = loading || ttsLoading;
-  const hasRunningTool = timeline.some(
+
+  const hasRunningTool = useMemo(() => timeline.some(
     (item) => item.kind === "tool" && item.call.status === "running",
-  );
+  ), [timeline]);
+
+  const hasAnyTool = useMemo(() => timeline.some((item) => item.kind === "tool"), [timeline]);
+
+  const renderedTimeline = useMemo(() => {
+    return timeline.map((item) => {
+      if (item.kind === "tool") {
+        return (
+          <ToolCallBubble
+            key={item.id}
+            call={item.call}
+            onConfirm={onToolConfirm}
+          />
+        );
+      }
+
+      const msg = timelineItemToMessage(item);
+      if (!msg) return null;
+      return (
+        <MessageBubble
+          key={item.id}
+          role={msg.role}
+          text={msg.text}
+          expression={msg.expression}
+          characterName={characterName}
+        />
+      );
+    });
+  }, [timeline, characterName, onToolConfirm]);
 
   return (
     <div className="flex-1 flex flex-col bg-transparent relative h-full">
@@ -301,29 +330,7 @@ export function ChatPanel({
           </div>
         )}
 
-        {timeline.map((item) => {
-          if (item.kind === "tool") {
-            return (
-              <ToolCallBubble
-                key={item.id}
-                call={item.call}
-                onConfirm={onToolConfirm}
-              />
-            );
-          }
-
-          const msg = timelineItemToMessage(item);
-          if (!msg) return null;
-          return (
-            <MessageBubble
-              key={item.id}
-              role={msg.role}
-              text={msg.text}
-              expression={msg.expression}
-              characterName={characterName}
-            />
-          );
-        })}
+        {renderedTimeline}
 
         {/* Streaming text — always the latest assistant turn */}
         {streamingText && (
@@ -357,7 +364,7 @@ export function ChatPanel({
                   <span className="w-2 h-2 rounded-full bg-blue-400/60 animate-bounce" />
                 </div>
                 <span className="text-xs font-semibold uppercase tracking-wide">
-                  {timeline.some((item) => item.kind === "tool") ? "Continuing" : "Thinking"}
+                  {hasAnyTool ? "Continuing" : "Thinking"}
                 </span>
               </div>
             </div>


### PR DESCRIPTION
**💡 What:** Wrapped expensive array operations (`timeline.some` and `timeline.map`) inside `src/components/ChatPanel.tsx` in `useMemo` hooks.
**🎯 Why:** The `ChatPanel` component re-renders highly frequently (e.g., token-by-token during streaming text generation). Previously, on every render, it was running O(N) array search and map operations to determine the loading state and rebuild the JSX elements for the chat history, causing a massive performance bottleneck as the history grew.
**📊 Impact:** Prevents O(N) recalculations on every render tick, significantly improving streaming text rendering performance and preventing UI stuttering on long conversations.
**🔬 Measurement:** Start a long conversation and observe the reduced CPU load and frame drops in the browser profiler while new messages are streaming.

---
*PR created automatically by Jules for task [7700516313205757744](https://jules.google.com/task/7700516313205757744) started by @meet447*