### PR TITLE
⚡ Bolt: Memoize O(N) timeline operations to prevent re-renders during streaming

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -21,3 +21,7 @@
 ## 2026-10-30 - Defeated React.memo via Object Recreation in Maps
 **Learning:** When rendering list items, mapping a timeline object to a new object on every render (e.g. `const msg = timelineItemToMessage(item)`) and passing it as a prop defeats `React.memo`'s shallow comparison, causing components to re-render constantly (e.g. during rapid text streaming).
 **Action:** Always pass primitive values extracted from the generated object, or pass the original stable item directly to memoized child components to ensure `React.memo` behaves efficiently and prevents O(N) re-renders.
+
+## 2024-07-01 - React Re-renders During AI Text Streaming
+**Learning:** In AI chat interfaces, rendering components that map over a growing history array (like `timeline`) and checking array states (like `timeline.some()`) natively triggers `O(N)` operations on every single streaming token update, leading to severe CPU spiking on fast connections.
+**Action:** Always wrap expensive list traversals and element recreations in `useMemo` when rendering streaming text chat interfaces to bypass the `O(N)` reconciliation cost on every keystroke/token. Ensure memoized React elements are hoisted out of inline JSX statements to avoid violations of the Rules of Hooks if conditional rendering is later applied.

--- a/src/components/ChatPanel.tsx
+++ b/src/components/ChatPanel.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect, useCallback, memo } from "react";
+import { useState, useRef, useEffect, useCallback, memo, useMemo } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import type { ChatMessage, ChatTimelineItem } from "../types";
@@ -281,9 +281,39 @@ export function ChatPanel({
   }, [timeline, streamingText]);
 
   const isProcessing = loading || ttsLoading;
-  const hasRunningTool = timeline.some(
+  // ⚡ Bolt: Memoize O(N) array traversals over the timeline array
+  // This prevents searching the entire chat history on every keystroke or streaming text token
+  const hasRunningTool = useMemo(() => timeline.some(
     (item) => item.kind === "tool" && item.call.status === "running",
-  );
+  ), [timeline]);
+
+  const hasAnyTool = useMemo(() => timeline.some((item) => item.kind === "tool"), [timeline]);
+
+
+  // ⚡ Bolt: Memoize timeline rendering to prevent O(N) recreations of React elements during fast streaming updates
+  const renderedTimeline = useMemo(() => timeline.map((item) => {
+    if (item.kind === "tool") {
+      return (
+        <ToolCallBubble
+          key={item.id}
+          call={item.call}
+          onConfirm={onToolConfirm}
+        />
+      );
+    }
+
+    const msg = timelineItemToMessage(item);
+    if (!msg) return null;
+    return (
+      <MessageBubble
+        key={item.id}
+        role={msg.role}
+        text={msg.text}
+        expression={msg.expression}
+        characterName={characterName}
+      />
+    );
+  }), [timeline, characterName, onToolConfirm]);
 
   return (
     <div className="flex-1 flex flex-col bg-transparent relative h-full">
@@ -301,29 +331,7 @@ export function ChatPanel({
           </div>
         )}
 
-        {timeline.map((item) => {
-          if (item.kind === "tool") {
-            return (
-              <ToolCallBubble
-                key={item.id}
-                call={item.call}
-                onConfirm={onToolConfirm}
-              />
-            );
-          }
-
-          const msg = timelineItemToMessage(item);
-          if (!msg) return null;
-          return (
-            <MessageBubble
-              key={item.id}
-              role={msg.role}
-              text={msg.text}
-              expression={msg.expression}
-              characterName={characterName}
-            />
-          );
-        })}
+        {renderedTimeline}
 
         {/* Streaming text — always the latest assistant turn */}
         {streamingText && (
@@ -357,7 +365,7 @@ export function ChatPanel({
                   <span className="w-2 h-2 rounded-full bg-blue-400/60 animate-bounce" />
                 </div>
                 <span className="text-xs font-semibold uppercase tracking-wide">
-                  {timeline.some((item) => item.kind === "tool") ? "Continuing" : "Thinking"}
+                  {hasAnyTool ? "Continuing" : "Thinking"}
                 </span>
               </div>
             </div>


### PR DESCRIPTION
💡 What: The optimization implements `useMemo` in `src/components/ChatPanel.tsx` to memoize the array operations (`timeline.some()`) and the creation of React elements via `timeline.map()`. The memoized rendering list is hoisted to prevent rule of hooks violations.

🎯 Why: In AI chat applications, the component is updated rapidly on every single text token that is streamed. Without memoization, traversing the chat history array and recreating all `MessageBubble` elements requires `O(N)` CPU operations on every render, leading to unnecessary CPU overhead and potential lag on long conversations.

📊 Impact: Reduces O(N) array traversals to O(1) during streaming and typing updates, bypassing full list reconciliation and avoiding re-renders on the chat timeline unless the timeline actually changes.

🔬 Measurement: Verifiable by monitoring React DevTools flamegraph during an active LLM streaming response. Tests ran and passed to ensure functionality remains identical.

---
*PR created automatically by Jules for task [14879970836593480449](https://jules.google.com/task/14879970836593480449) started by @meet447*