### PR TITLE
⚡ Bolt: Optimize ChatPanel to prevent O(N) re-renders during text streaming

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -21,3 +21,7 @@
 ## 2026-10-30 - Defeated React.memo via Object Recreation in Maps
 **Learning:** When rendering list items, mapping a timeline object to a new object on every render (e.g. `const msg = timelineItemToMessage(item)`) and passing it as a prop defeats `React.memo`'s shallow comparison, causing components to re-render constantly (e.g. during rapid text streaming).
 **Action:** Always pass primitive values extracted from the generated object, or pass the original stable item directly to memoized child components to ensure `React.memo` behaves efficiently and prevents O(N) re-renders.
+
+## 2025-06-25 - Prevent O(N) re-renders in chat interfaces
+**Learning:** In React chat interfaces, expensive O(N) array operations (`.map`, `.some`) on the message history recreate arrays and React elements on every rapid text streaming update (token-by-token), causing garbage collection spikes and CPU bottlenecks. Passing newly created objects to `React.memo` components also defeats shallow comparisons.
+**Action:** Use `useMemo` keyed to the history array to cache list transformations and search results so they only compute when new messages or tools arrive. Destructure objects into primitive props when passing data to `React.memo` components.

--- a/src/components/ChatPanel.tsx
+++ b/src/components/ChatPanel.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect, useCallback, memo } from "react";
+import { useState, useRef, useEffect, useCallback, memo, useMemo } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import type { ChatMessage, ChatTimelineItem } from "../types";
@@ -281,9 +281,44 @@ export function ChatPanel({
   }, [timeline, streamingText]);
 
   const isProcessing = loading || ttsLoading;
-  const hasRunningTool = timeline.some(
-    (item) => item.kind === "tool" && item.call.status === "running",
-  );
+
+  // ⚡ Bolt: Memoize expensive O(N) array operations that shouldn't re-run on every single
+  // token during text streaming.
+  const hasRunningTool = useMemo(() =>
+    timeline.some((item) => item.kind === "tool" && item.call.status === "running"),
+  [timeline]);
+
+  const hasToolCall = useMemo(() =>
+    timeline.some((item) => item.kind === "tool"),
+  [timeline]);
+
+  // ⚡ Bolt: Memoize the rendered messages list to prevent O(N) re-renders of the entire chat history
+  // on every token update.
+  const renderedMessages = useMemo(() =>
+    timeline.map((item) => {
+      if (item.kind === "tool") {
+        return (
+          <ToolCallBubble
+            key={item.id}
+            call={item.call}
+            onConfirm={onToolConfirm}
+          />
+        );
+      }
+
+      const msg = timelineItemToMessage(item);
+      if (!msg) return null;
+      return (
+        <MessageBubble
+          key={item.id}
+          role={msg.role}
+          text={msg.text}
+          expression={msg.expression}
+          characterName={characterName}
+        />
+      );
+    }),
+  [timeline, characterName, onToolConfirm]);
 
   return (
     <div className="flex-1 flex flex-col bg-transparent relative h-full">
@@ -301,29 +336,7 @@ export function ChatPanel({
           </div>
         )}
 
-        {timeline.map((item) => {
-          if (item.kind === "tool") {
-            return (
-              <ToolCallBubble
-                key={item.id}
-                call={item.call}
-                onConfirm={onToolConfirm}
-              />
-            );
-          }
-
-          const msg = timelineItemToMessage(item);
-          if (!msg) return null;
-          return (
-            <MessageBubble
-              key={item.id}
-              role={msg.role}
-              text={msg.text}
-              expression={msg.expression}
-              characterName={characterName}
-            />
-          );
-        })}
+        {renderedMessages}
 
         {/* Streaming text — always the latest assistant turn */}
         {streamingText && (
@@ -357,7 +370,7 @@ export function ChatPanel({
                   <span className="w-2 h-2 rounded-full bg-blue-400/60 animate-bounce" />
                 </div>
                 <span className="text-xs font-semibold uppercase tracking-wide">
-                  {timeline.some((item) => item.kind === "tool") ? "Continuing" : "Thinking"}
+                  {hasToolCall ? "Continuing" : "Thinking"}
                 </span>
               </div>
             </div>


### PR DESCRIPTION
## 💡 What
Wrapped expensive `timeline` array operations in `useMemo` within `src/components/ChatPanel.tsx`. Specifically:
1. `hasRunningTool` and `hasToolCall` inline checks were extracted to memoized booleans.
2. The `timeline.map(...)` block that instantiates `ToolCallBubble` and `MessageBubble` components was wrapped into a memoized `renderedMessages` variable.

## 🎯 Why
During rapid text streaming (e.g., token-by-token from an LLM), the `streamingText` state updates frequently (dozens of times per second). Previously, these state updates triggered the entire `ChatPanel` component to re-render, forcing O(N) evaluations of `timeline.some()` and `timeline.map()` on every token. This created a performance bottleneck on long conversations, causing garbage collection spikes and CPU thrashing.

## 📊 Impact
Eliminates O(N) array traversals and React element re-instantiations on every streaming token. Reduces CPU usage during text streaming, allowing the chat UI to remain responsive even with very large conversation histories.

## 🔬 Measurement
Verified by running `vitest`, `tsc`, and Playwright UI scripts to ensure no visual regressions or logic errors occurred. The change passes all existing component tests.

---
*PR created automatically by Jules for task [13013752797584238609](https://jules.google.com/task/13013752797584238609) started by @meet447*