### PR TITLE
⚡ Bolt: Memoize timeline O(N) array scans during streaming

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -21,3 +21,7 @@
 ## 2026-10-30 - Defeated React.memo via Object Recreation in Maps
 **Learning:** When rendering list items, mapping a timeline object to a new object on every render (e.g. `const msg = timelineItemToMessage(item)`) and passing it as a prop defeats `React.memo`'s shallow comparison, causing components to re-render constantly (e.g. during rapid text streaming).
 **Action:** Always pass primitive values extracted from the generated object, or pass the original stable item directly to memoized child components to ensure `React.memo` behaves efficiently and prevents O(N) re-renders.
+
+## 2024-05-18 - React Array Scanning During Rapid Renders
+**Learning:** Performing inline O(N) array operations (like `.some()`, `.every()`, or `.filter()`) inside the main body of a React functional component causes massive performance bottlenecks if the component renders frequently (e.g., during rapid text streaming token updates). If the array reference doesn't change, the CPU cycles are completely wasted.
+**Action:** Always wrap heavy list traversals/scans in `useMemo` hooks, keyed to the underlying data structure reference (e.g., `[timeline]`), to ensure they are only executed when the array actually changes, not on every render cycle.

--- a/src/components/ChatPanel.tsx
+++ b/src/components/ChatPanel.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect, useCallback, memo } from "react";
+import { useState, useRef, useEffect, useCallback, memo, useMemo } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import type { ChatMessage, ChatTimelineItem } from "../types";
@@ -281,9 +281,17 @@ export function ChatPanel({
   }, [timeline, streamingText]);
 
   const isProcessing = loading || ttsLoading;
-  const hasRunningTool = timeline.some(
-    (item) => item.kind === "tool" && item.call.status === "running",
-  );
+
+  // ⚡ Bolt: Memoize O(N) array scans (timeline.some) keyed to the `timeline` array.
+  // During rapid text streaming, `ChatPanel` re-renders constantly.
+  // Memoizing these avoids scanning the entire message history on every single token update.
+  const hasRunningTool = useMemo(() =>
+    timeline.some((item) => item.kind === "tool" && item.call.status === "running"),
+  [timeline]);
+
+  const hasAnyTool = useMemo(() =>
+    timeline.some((item) => item.kind === "tool"),
+  [timeline]);
 
   return (
     <div className="flex-1 flex flex-col bg-transparent relative h-full">
@@ -357,7 +365,7 @@ export function ChatPanel({
                   <span className="w-2 h-2 rounded-full bg-blue-400/60 animate-bounce" />
                 </div>
                 <span className="text-xs font-semibold uppercase tracking-wide">
-                  {timeline.some((item) => item.kind === "tool") ? "Continuing" : "Thinking"}
+                  {hasAnyTool ? "Continuing" : "Thinking"}
                 </span>
               </div>
             </div>


### PR DESCRIPTION
💡 **What:** Wrapped `timeline.some()` array iteration operations in `ChatPanel.tsx` in `useMemo` hooks, keyed to the `timeline` array.
🎯 **Why:** Previously, checking if tools were currently running or had ever been run required iterating over the entire message history on *every single render*. Since the `ChatPanel` re-renders extremely frequently during rapid text streaming (sometimes hundreds of times per second depending on token speed), this resulted in wasted O(N) CPU cycles.
📊 **Impact:** Reduces CPU usage and blocks main-thread jank during rapid LLM token streaming by ensuring `hasRunningTool` and `hasAnyTool` are only recalculated when the `timeline` array itself changes, not during unrelated streaming state updates.
🔬 **Measurement:** Start a chat with the assistant and stream a long response. Use React DevTools Profiler or the Chrome DevTools Performance tab to measure `ChatPanel` render times. You will notice the base render cost during token streams is noticeably reduced since it no longer performs array iteration on every tick.

---
*PR created automatically by Jules for task [5122069695958485315](https://jules.google.com/task/5122069695958485315) started by @meet447*