### PR TITLE
⚡ Bolt: Memoize O(N) array operations in ChatPanel

### DIFF
--- a/src/components/ChatPanel.tsx
+++ b/src/components/ChatPanel.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect, useCallback, memo } from "react";
+import { useState, useRef, useEffect, useCallback, memo, useMemo } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import type { ChatMessage, ChatTimelineItem } from "../types";
@@ -281,9 +281,38 @@ export function ChatPanel({
   }, [timeline, streamingText]);
 
   const isProcessing = loading || ttsLoading;
-  const hasRunningTool = timeline.some(
+  const hasRunningTool = useMemo(() => timeline.some(
     (item) => item.kind === "tool" && item.call.status === "running",
-  );
+  ), [timeline]);
+  const hasContinuingTool = useMemo(() => timeline.some(
+    (item) => item.kind === "tool"
+  ), [timeline]);
+
+  const timelineMessages = useMemo(() => {
+    return timeline.map((item) => {
+      if (item.kind === "tool") {
+        return (
+          <ToolCallBubble
+            key={item.id}
+            call={item.call}
+            onConfirm={onToolConfirm}
+          />
+        );
+      }
+
+      const msg = timelineItemToMessage(item);
+      if (!msg) return null;
+      return (
+        <MessageBubble
+          key={item.id}
+          role={msg.role}
+          text={msg.text}
+          expression={msg.expression}
+          characterName={characterName}
+        />
+      );
+    });
+  }, [timeline, characterName, onToolConfirm]);
 
   return (
     <div className="flex-1 flex flex-col bg-transparent relative h-full">
@@ -301,29 +330,7 @@ export function ChatPanel({
           </div>
         )}
 
-        {timeline.map((item) => {
-          if (item.kind === "tool") {
-            return (
-              <ToolCallBubble
-                key={item.id}
-                call={item.call}
-                onConfirm={onToolConfirm}
-              />
-            );
-          }
-
-          const msg = timelineItemToMessage(item);
-          if (!msg) return null;
-          return (
-            <MessageBubble
-              key={item.id}
-              role={msg.role}
-              text={msg.text}
-              expression={msg.expression}
-              characterName={characterName}
-            />
-          );
-        })}
+        {timelineMessages}
 
         {/* Streaming text — always the latest assistant turn */}
         {streamingText && (
@@ -357,7 +364,7 @@ export function ChatPanel({
                   <span className="w-2 h-2 rounded-full bg-blue-400/60 animate-bounce" />
                 </div>
                 <span className="text-xs font-semibold uppercase tracking-wide">
-                  {timeline.some((item) => item.kind === "tool") ? "Continuing" : "Thinking"}
+                  {hasContinuingTool ? "Continuing" : "Thinking"}
                 </span>
               </div>
             </div>


### PR DESCRIPTION
### 💡 What
Wrapped expensive O(N) array operations (`timeline.some`, `timeline.map`) inside `useMemo` hooks in `src/components/ChatPanel.tsx`.

### 🎯 Why
In LLM chat interfaces, streaming text updates trigger frequent re-renders of the entire `ChatPanel` component (often multiple times per second as tokens arrive). Without memoization, `timeline.some` and `timeline.map` are executed on every single render, causing O(N) array scans and recreating the entire list of React elements for historical messages. This can cause significant UI stuttering and CPU overhead as the conversation history grows.

### 📊 Impact
Prevents O(N) array traversals and React element recreations during streaming text updates, significantly reducing CPU usage and making the UI much smoother during generation.

### 🔬 Measurement
Start a chat, generate a long message, and observe React Profiler or Chrome DevTools Performance tab. You will see that only the new streaming message bubble updates, while the historical messages and `timeline` processing bail out of reconciliation.

---
*PR created automatically by Jules for task [1954393432684119370](https://jules.google.com/task/1954393432684119370) started by @meet447*