### PR TITLE
⚡ Bolt: Memoize timeline renders in ChatPanel to prevent O(N) recalculations

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -21,3 +21,7 @@
 ## 2026-10-30 - Defeated React.memo via Object Recreation in Maps
 **Learning:** When rendering list items, mapping a timeline object to a new object on every render (e.g. `const msg = timelineItemToMessage(item)`) and passing it as a prop defeats `React.memo`'s shallow comparison, causing components to re-render constantly (e.g. during rapid text streaming).
 **Action:** Always pass primitive values extracted from the generated object, or pass the original stable item directly to memoized child components to ensure `React.memo` behaves efficiently and prevents O(N) re-renders.
+
+## 2023-11-10 - O(N) Array Operations in React Render Phase
+**Learning:** Performing `Array.prototype.map` and `Array.prototype.some` operations on potentially large arrays (like a chat timeline) during every render cycle causes significant performance drops, especially during rapid streaming events (like per-token LLM output).
+**Action:** Always wrap `map`, `filter`, and `some` calls on large lists in `useMemo` hooks, keyed specifically to the list and any other dependencies required to generate the mapped components or boolean flags.

--- a/src/components/ChatPanel.tsx
+++ b/src/components/ChatPanel.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect, useCallback, memo } from "react";
+import { useState, useRef, useEffect, useCallback, memo, useMemo } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import type { ChatMessage, ChatTimelineItem } from "../types";
@@ -281,9 +281,43 @@ export function ChatPanel({
   }, [timeline, streamingText]);
 
   const isProcessing = loading || ttsLoading;
-  const hasRunningTool = timeline.some(
-    (item) => item.kind === "tool" && item.call.status === "running",
-  );
+
+  // ⚡ Bolt: Memoizing these O(N) array operations over the timeline prevents
+  // traversing the entire message history and recreating React elements on every
+  // rapid text streaming update (which occurs per-token).
+  const hasRunningTool = useMemo(() =>
+    timeline.some((item) => item.kind === "tool" && item.call.status === "running"),
+  [timeline]);
+
+  const hasAnyTool = useMemo(() =>
+    timeline.some((item) => item.kind === "tool"),
+  [timeline]);
+
+  const renderedTimeline = useMemo(() => {
+    return timeline.map((item) => {
+      if (item.kind === "tool") {
+        return (
+          <ToolCallBubble
+            key={item.id}
+            call={item.call}
+            onConfirm={onToolConfirm}
+          />
+        );
+      }
+
+      const msg = timelineItemToMessage(item);
+      if (!msg) return null;
+      return (
+        <MessageBubble
+          key={item.id}
+          role={msg.role}
+          text={msg.text}
+          expression={msg.expression}
+          characterName={characterName}
+        />
+      );
+    });
+  }, [timeline, onToolConfirm, characterName]);
 
   return (
     <div className="flex-1 flex flex-col bg-transparent relative h-full">
@@ -301,29 +335,7 @@ export function ChatPanel({
           </div>
         )}
 
-        {timeline.map((item) => {
-          if (item.kind === "tool") {
-            return (
-              <ToolCallBubble
-                key={item.id}
-                call={item.call}
-                onConfirm={onToolConfirm}
-              />
-            );
-          }
-
-          const msg = timelineItemToMessage(item);
-          if (!msg) return null;
-          return (
-            <MessageBubble
-              key={item.id}
-              role={msg.role}
-              text={msg.text}
-              expression={msg.expression}
-              characterName={characterName}
-            />
-          );
-        })}
+        {renderedTimeline}
 
         {/* Streaming text — always the latest assistant turn */}
         {streamingText && (
@@ -357,7 +369,7 @@ export function ChatPanel({
                   <span className="w-2 h-2 rounded-full bg-blue-400/60 animate-bounce" />
                 </div>
                 <span className="text-xs font-semibold uppercase tracking-wide">
-                  {timeline.some((item) => item.kind === "tool") ? "Continuing" : "Thinking"}
+                  {hasAnyTool ? "Continuing" : "Thinking"}
                 </span>
               </div>
             </div>


### PR DESCRIPTION
## What
Wrapped `timeline.some` and `timeline.map` iterations inside `src/components/ChatPanel.tsx` in `useMemo` hooks.

## Why
During rapid LLM text streaming, the `streamingText` prop updates token-by-token. This causes the `ChatPanel` component to re-render repeatedly. Before this change, the entire `timeline` array was traversed multiple times via `.some()` and `.map()` to re-generate the full list of message bubbles on *every* token, which resulted in O(N) operations scaling with conversation length inside the render cycle.

## Impact
Prevents traversing the entire message history and recreating React elements on every streaming text update, resulting in smoother text streaming and lower CPU utilization as the chat history grows.

## Measurement
Launch the application and send multiple long messages. Profile the rendering performance using React DevTools while text is streaming; you will see fewer component re-renders and faster render commit times.

---
*PR created automatically by Jules for task [2729408452438725411](https://jules.google.com/task/2729408452438725411) started by @meet447*