### PR TITLE
⚡ Bolt: Memoize timeline processing in ChatPanel

### DIFF
--- a/src/components/ChatPanel.tsx
+++ b/src/components/ChatPanel.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect, useCallback, memo } from "react";
+import { useState, useRef, useEffect, useCallback, memo, useMemo } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import type { ChatMessage, ChatTimelineItem } from "../types";
@@ -281,9 +281,38 @@ export function ChatPanel({
   }, [timeline, streamingText]);
 
   const isProcessing = loading || ttsLoading;
-  const hasRunningTool = timeline.some(
+  // ⚡ Bolt: Cache array iteration over timeline to prevent O(N) evaluation on every keystroke/streaming token
+  const hasRunningTool = useMemo(() => timeline.some(
     (item) => item.kind === "tool" && item.call.status === "running",
-  );
+  ), [timeline]);
+
+  const hasAnyTool = useMemo(() => timeline.some((item) => item.kind === "tool"), [timeline]);
+
+  // ⚡ Bolt: Memoize the mapping of history elements to prevent deep recreation
+  // and O(N) rendering passes of all past messages while text streams rapidly.
+  const renderedMessages = useMemo(() => timeline.map((item) => {
+    if (item.kind === "tool") {
+      return (
+        <ToolCallBubble
+          key={item.id}
+          call={item.call}
+          onConfirm={onToolConfirm}
+        />
+      );
+    }
+
+    const msg = timelineItemToMessage(item);
+    if (!msg) return null;
+    return (
+      <MessageBubble
+        key={item.id}
+        role={msg.role}
+        text={msg.text}
+        expression={msg.expression}
+        characterName={characterName}
+      />
+    );
+  }), [timeline, characterName, onToolConfirm]);
 
   return (
     <div className="flex-1 flex flex-col bg-transparent relative h-full">
@@ -301,29 +330,7 @@ export function ChatPanel({
           </div>
         )}
 
-        {timeline.map((item) => {
-          if (item.kind === "tool") {
-            return (
-              <ToolCallBubble
-                key={item.id}
-                call={item.call}
-                onConfirm={onToolConfirm}
-              />
-            );
-          }
-
-          const msg = timelineItemToMessage(item);
-          if (!msg) return null;
-          return (
-            <MessageBubble
-              key={item.id}
-              role={msg.role}
-              text={msg.text}
-              expression={msg.expression}
-              characterName={characterName}
-            />
-          );
-        })}
+        {renderedMessages}
 
         {/* Streaming text — always the latest assistant turn */}
         {streamingText && (
@@ -357,7 +364,7 @@ export function ChatPanel({
                   <span className="w-2 h-2 rounded-full bg-blue-400/60 animate-bounce" />
                 </div>
                 <span className="text-xs font-semibold uppercase tracking-wide">
-                  {timeline.some((item) => item.kind === "tool") ? "Continuing" : "Thinking"}
+                  {hasAnyTool ? "Continuing" : "Thinking"}
                 </span>
               </div>
             </div>


### PR DESCRIPTION
💡 What: Wrapped the `timeline.map` and `timeline.some` array operations inside `useMemo` in `ChatPanel.tsx`, keyed to the `timeline` dependency.

🎯 Why: Managing text input state at the top level or during rapid token-by-token streaming causes O(N) array recreation and evaluations (like traversing the entire history) on every keystroke/streaming token update, leading to significant performance bottlenecks and unnecessary garbage collection overhead.

📊 Impact: Reduces O(N) evaluations and rendering passes of all past messages while text streams rapidly, maintaining O(1) rendering cost for previously stable list items.

🔬 Measurement: Verified by observing a reduction in performance overhead during streaming token updates without creating deep recreation and full-list traversals.

---
*PR created automatically by Jules for task [5944676438319501688](https://jules.google.com/task/5944676438319501688) started by @meet447*