### PR TITLE
⚡ Bolt: Extract timeline array iterations to useMemo to avoid O(N) re-renders in ChatPanel

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -21,3 +21,7 @@
 ## 2026-10-30 - Defeated React.memo via Object Recreation in Maps
 **Learning:** When rendering list items, mapping a timeline object to a new object on every render (e.g. `const msg = timelineItemToMessage(item)`) and passing it as a prop defeats `React.memo`'s shallow comparison, causing components to re-render constantly (e.g. during rapid text streaming).
 **Action:** Always pass primitive values extracted from the generated object, or pass the original stable item directly to memoized child components to ensure `React.memo` behaves efficiently and prevents O(N) re-renders.
+
+## 2026-07-13 - ChatPanel React List Re-renders due to Array Map in Render
+**Learning:** Mapping over arrays inside the React render function (e.g. `timeline.map(...)`) creates new React element references every time, and extracting array derivation logic (like `.some()`) is expensive if the array is frequently updated or just constantly processed during fast render cycles like streaming text.
+**Action:** Extract expensive list map operations (and `.some` condition checks over the array) inside list components (like `ChatPanel.tsx`) using `useMemo` keyed on the array and any primitive dependencies. This prevents O(N) array recreation and avoids re-rendering the message history unless the dependencies actually change.

--- a/src/components/ChatPanel.tsx
+++ b/src/components/ChatPanel.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect, useCallback, memo } from "react";
+import { useState, useRef, useEffect, useCallback, memo, useMemo } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import type { ChatMessage, ChatTimelineItem } from "../types";
@@ -281,9 +281,42 @@ export function ChatPanel({
   }, [timeline, streamingText]);
 
   const isProcessing = loading || ttsLoading;
-  const hasRunningTool = timeline.some(
-    (item) => item.kind === "tool" && item.call.status === "running",
+
+  const hasRunningTool = useMemo(
+    () => timeline.some((item) => item.kind === "tool" && item.call.status === "running"),
+    [timeline]
   );
+
+  const hasAnyTool = useMemo(
+    () => timeline.some((item) => item.kind === "tool"),
+    [timeline]
+  );
+
+  const renderedMessages = useMemo(() => {
+    return timeline.map((item) => {
+      if (item.kind === "tool") {
+        return (
+          <ToolCallBubble
+            key={item.id}
+            call={item.call}
+            onConfirm={onToolConfirm}
+          />
+        );
+      }
+
+      const msg = timelineItemToMessage(item);
+      if (!msg) return null;
+      return (
+        <MessageBubble
+          key={item.id}
+          role={msg.role}
+          text={msg.text}
+          expression={msg.expression}
+          characterName={characterName}
+        />
+      );
+    });
+  }, [timeline, characterName, onToolConfirm]);
 
   return (
     <div className="flex-1 flex flex-col bg-transparent relative h-full">
@@ -301,29 +334,7 @@ export function ChatPanel({
           </div>
         )}
 
-        {timeline.map((item) => {
-          if (item.kind === "tool") {
-            return (
-              <ToolCallBubble
-                key={item.id}
-                call={item.call}
-                onConfirm={onToolConfirm}
-              />
-            );
-          }
-
-          const msg = timelineItemToMessage(item);
-          if (!msg) return null;
-          return (
-            <MessageBubble
-              key={item.id}
-              role={msg.role}
-              text={msg.text}
-              expression={msg.expression}
-              characterName={characterName}
-            />
-          );
-        })}
+        {renderedMessages}
 
         {/* Streaming text — always the latest assistant turn */}
         {streamingText && (
@@ -357,7 +368,7 @@ export function ChatPanel({
                   <span className="w-2 h-2 rounded-full bg-blue-400/60 animate-bounce" />
                 </div>
                 <span className="text-xs font-semibold uppercase tracking-wide">
-                  {timeline.some((item) => item.kind === "tool") ? "Continuing" : "Thinking"}
+                  {hasAnyTool ? "Continuing" : "Thinking"}
                 </span>
               </div>
             </div>


### PR DESCRIPTION
💡 **What:** The optimization extracts `timeline.map` and `timeline.some` operations into `useMemo` hooks in the `ChatPanel` component.

🎯 **Why:** In a chat interface with streaming text, the `ChatPanel` re-renders frequently. Mapping over the `timeline` array to generate `MessageBubble` components inside the render loop causes O(N) array traversals and object recreations on every single render cycle, even when the timeline itself hasn't changed.

📊 **Impact:** Significantly reduces CPU overhead during fast render cycles (e.g., token-by-token text streaming) by avoiding unnecessary array iterations and object allocations for the entire message history.

🔬 **Measurement:** Use React Developer Tools Profiler. Record a session while text is streaming. Observe that the render time and memory allocations for `ChatPanel` are reduced, as the `renderedMessages` are cached and not recalculated on every token.

---
*PR created automatically by Jules for task [7785713333837801256](https://jules.google.com/task/7785713333837801256) started by @meet447*