### PR TITLE
⚡ Bolt: memoize heavy timeline operations in ChatPanel to prevent O(N) streaming re-renders

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -21,3 +21,7 @@
 ## 2026-10-30 - Defeated React.memo via Object Recreation in Maps
 **Learning:** When rendering list items, mapping a timeline object to a new object on every render (e.g. `const msg = timelineItemToMessage(item)`) and passing it as a prop defeats `React.memo`'s shallow comparison, causing components to re-render constantly (e.g. during rapid text streaming).
 **Action:** Always pass primitive values extracted from the generated object, or pass the original stable item directly to memoized child components to ensure `React.memo` behaves efficiently and prevents O(N) re-renders.
+
+## 2026-07-14 - ChatPanel Render Tree Memoization
+**Learning:** In React components that render large lists based on rapidly updating state (like `streamingText` updating every few milliseconds with new tokens), recalculating the entire rendered array or performing expensive `.some()` checks across the whole timeline on every render causes massive CPU overhead and defeats the purpose of individual item memoization.
+**Action:** Always wrap the entire rendered list node array (e.g. `const renderedTimeline = useMemo(() => timeline.map(...), [timeline])`) in `useMemo` so that the heavy lifting of iterating over the list and building React elements only happens when the list itself changes, not when unrelated sibling state like `streamingText` streams in.

--- a/src/components/ChatPanel.tsx
+++ b/src/components/ChatPanel.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect, useCallback, memo } from "react";
+import { useState, useRef, useEffect, useCallback, memo, useMemo } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import type { ChatMessage, ChatTimelineItem } from "../types";
@@ -281,9 +281,42 @@ export function ChatPanel({
   }, [timeline, streamingText]);
 
   const isProcessing = loading || ttsLoading;
-  const hasRunningTool = timeline.some(
-    (item) => item.kind === "tool" && item.call.status === "running",
-  );
+
+  const hasRunningTool = useMemo(() => {
+    return timeline.some(
+      (item) => item.kind === "tool" && item.call.status === "running",
+    );
+  }, [timeline]);
+
+  const hasAnyTool = useMemo(() => {
+    return timeline.some((item) => item.kind === "tool");
+  }, [timeline]);
+
+  const renderedTimeline = useMemo(() => {
+    return timeline.map((item) => {
+      if (item.kind === "tool") {
+        return (
+          <ToolCallBubble
+            key={item.id}
+            call={item.call}
+            onConfirm={onToolConfirm}
+          />
+        );
+      }
+
+      const msg = timelineItemToMessage(item);
+      if (!msg) return null;
+      return (
+        <MessageBubble
+          key={item.id}
+          role={msg.role}
+          text={msg.text}
+          expression={msg.expression}
+          characterName={characterName}
+        />
+      );
+    });
+  }, [timeline, onToolConfirm, characterName]);
 
   return (
     <div className="flex-1 flex flex-col bg-transparent relative h-full">
@@ -301,29 +334,7 @@ export function ChatPanel({
           </div>
         )}
 
-        {timeline.map((item) => {
-          if (item.kind === "tool") {
-            return (
-              <ToolCallBubble
-                key={item.id}
-                call={item.call}
-                onConfirm={onToolConfirm}
-              />
-            );
-          }
-
-          const msg = timelineItemToMessage(item);
-          if (!msg) return null;
-          return (
-            <MessageBubble
-              key={item.id}
-              role={msg.role}
-              text={msg.text}
-              expression={msg.expression}
-              characterName={characterName}
-            />
-          );
-        })}
+        {renderedTimeline}
 
         {/* Streaming text — always the latest assistant turn */}
         {streamingText && (
@@ -357,7 +368,7 @@ export function ChatPanel({
                   <span className="w-2 h-2 rounded-full bg-blue-400/60 animate-bounce" />
                 </div>
                 <span className="text-xs font-semibold uppercase tracking-wide">
-                  {timeline.some((item) => item.kind === "tool") ? "Continuing" : "Thinking"}
+                  {hasAnyTool ? "Continuing" : "Thinking"}
                 </span>
               </div>
             </div>


### PR DESCRIPTION
### 💡 What
Memoized the `timeline.map(...)` iteration that produces the `MessageBubble` and `ToolCallBubble` React nodes, as well as the `timeline.some(...)` operations that check for tool calls, using `useMemo` keyed on `[timeline]`.

### 🎯 Why
In the `ChatPanel` component, the entire timeline array was being mapped over to create new React elements on *every single render*. When text is streaming in rapidly token-by-token (via the `streamingText` state), this caused `O(N)` mapping operations on the entire history for every few milliseconds, causing massive CPU overhead and defeating the purpose of shallow comparisons in children components. 

### 📊 Impact
Reduces `ChatPanel` re-render overhead significantly during text streaming. The array mapping and boolean check iterations are now only performed when the `timeline` state actually changes (e.g. a new message arrives), not when unrelated sibling state like `streamingText` streams in.

### 🔬 Measurement
Load a chat with a long history of messages and watch the CPU usage/React Profiler during a long streaming response. The number of React elements created and the time spent in `ChatPanel`'s render function is dramatically reduced.

---
*PR created automatically by Jules for task [1125198783045777104](https://jules.google.com/task/1125198783045777104) started by @meet447*