### PR TITLE
⚡ Bolt: Memoize chat history elements to prevent O(N) re-renders during text streaming

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -21,3 +21,7 @@
 ## 2026-10-30 - Defeated React.memo via Object Recreation in Maps
 **Learning:** When rendering list items, mapping a timeline object to a new object on every render (e.g. `const msg = timelineItemToMessage(item)`) and passing it as a prop defeats `React.memo`'s shallow comparison, causing components to re-render constantly (e.g. during rapid text streaming).
 **Action:** Always pass primitive values extracted from the generated object, or pass the original stable item directly to memoized child components to ensure `React.memo` behaves efficiently and prevents O(N) re-renders.
+
+## 2026-10-31 - React.memo Unnecessary Component Rerendering Avoidance
+**Learning:** `Array.map` combined with passing newly-created object arrays into rendering contexts can lead to significant re-render latency in high-update applications (like rapid text streams in chat applications). Wrapping the rendered component map in a `useMemo` blocks recreating the components down the tree on unrelated updates.
+**Action:** When a high-frequency status element updates on the same level as large array representations, always `useMemo` the array map rendering itself to block React from recalculating references and unnecessarily executing reconciliation.

--- a/src/components/ChatPanel.tsx
+++ b/src/components/ChatPanel.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect, useCallback, memo } from "react";
+import { useState, useRef, useEffect, useCallback, memo, useMemo } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import type { ChatMessage, ChatTimelineItem } from "../types";
@@ -281,9 +281,39 @@ export function ChatPanel({
   }, [timeline, streamingText]);
 
   const isProcessing = loading || ttsLoading;
-  const hasRunningTool = timeline.some(
+
+  // ⚡ Bolt: Memoize the running tool check to avoid O(N) traversal on every streaming update
+  const hasRunningTool = useMemo(() => timeline.some(
     (item) => item.kind === "tool" && item.call.status === "running",
-  );
+  ), [timeline]);
+
+  // ⚡ Bolt: Memoize the tool continuation check to avoid O(N) traversal on every streaming update
+  const isContinuing = useMemo(() => timeline.some((item) => item.kind === "tool"), [timeline]);
+
+  // ⚡ Bolt: Memoize the timeline mapping to prevent O(N) recreation of React elements on every text stream tick
+  const renderedTimeline = useMemo(() => timeline.map((item) => {
+    if (item.kind === "tool") {
+      return (
+        <ToolCallBubble
+          key={item.id}
+          call={item.call}
+          onConfirm={onToolConfirm}
+        />
+      );
+    }
+
+    const msg = timelineItemToMessage(item);
+    if (!msg) return null;
+    return (
+      <MessageBubble
+        key={item.id}
+        role={msg.role}
+        text={msg.text}
+        expression={msg.expression}
+        characterName={characterName}
+      />
+    );
+  }), [timeline, characterName, onToolConfirm]);
 
   return (
     <div className="flex-1 flex flex-col bg-transparent relative h-full">
@@ -301,29 +331,7 @@ export function ChatPanel({
           </div>
         )}
 
-        {timeline.map((item) => {
-          if (item.kind === "tool") {
-            return (
-              <ToolCallBubble
-                key={item.id}
-                call={item.call}
-                onConfirm={onToolConfirm}
-              />
-            );
-          }
-
-          const msg = timelineItemToMessage(item);
-          if (!msg) return null;
-          return (
-            <MessageBubble
-              key={item.id}
-              role={msg.role}
-              text={msg.text}
-              expression={msg.expression}
-              characterName={characterName}
-            />
-          );
-        })}
+        {renderedTimeline}
 
         {/* Streaming text — always the latest assistant turn */}
         {streamingText && (
@@ -357,7 +365,7 @@ export function ChatPanel({
                   <span className="w-2 h-2 rounded-full bg-blue-400/60 animate-bounce" />
                 </div>
                 <span className="text-xs font-semibold uppercase tracking-wide">
-                  {timeline.some((item) => item.kind === "tool") ? "Continuing" : "Thinking"}
+                  {isContinuing ? "Continuing" : "Thinking"}
                 </span>
               </div>
             </div>


### PR DESCRIPTION
💡 What: Extracted and wrapped the `timeline.map()` rendering logic and `.some()` tool checks in `useMemo` at the top level of `ChatPanel.tsx`.

🎯 Why: In the chat interface, rapidly streaming text caused the parent `ChatPanel` component to re-render on every token update. This led to an O(N) recreation of all React elements for the entire chat history on every tick.

📊 Impact: Significantly reduces CPU usage and jank by allowing React to completely skip reconciling historical messages during text streams.

🔬 Measurement: Verify by typing quickly or observing CPU utilization when a large message is streamed back; there should be a notable drop in main-thread blocking.

---
*PR created automatically by Jules for task [1865573385375023050](https://jules.google.com/task/1865573385375023050) started by @meet447*