### PR TITLE
⚡ Bolt: Memoize expensive O(N) timeline iterations in ChatPanel

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -21,3 +21,7 @@
 ## 2026-10-30 - Defeated React.memo via Object Recreation in Maps
 **Learning:** When rendering list items, mapping a timeline object to a new object on every render (e.g. `const msg = timelineItemToMessage(item)`) and passing it as a prop defeats `React.memo`'s shallow comparison, causing components to re-render constantly (e.g. during rapid text streaming).
 **Action:** Always pass primitive values extracted from the generated object, or pass the original stable item directly to memoized child components to ensure `React.memo` behaves efficiently and prevents O(N) re-renders.
+
+## 2026-11-10 - Memoizing Expensive O(N) Iterations in React Chat Interfaces
+**Learning:** In chat interfaces, rapidly streaming text (token-by-token) triggers frequent state updates. If expensive O(N) array operations (like `.map()` for generating JSX elements or `.some()` for checking conditions) are executed on the main message history array during the render loop, it causes significant CPU overhead and dropped frames as the history grows.
+**Action:** Always wrap O(N) array iterations in `useMemo` hooks keyed to the history array reference when dealing with frequently updating disjoint state (like streaming text tokens). This prevents traversing the entire history and recreating React elements on every single streaming text update.

--- a/dev_server.log
+++ b/dev_server.log
@@ -1,0 +1,8 @@
+
+> meuxcompanion-desktop@0.1.0 dev
+> vite
+
+
+  VITE v6.4.1  ready in 518 ms
+
+  ➜  Local:   http://localhost:1420/

--- a/src/components/ChatPanel.tsx
+++ b/src/components/ChatPanel.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect, useCallback, memo } from "react";
+import React, { useState, useRef, useEffect, useCallback, memo } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import type { ChatMessage, ChatTimelineItem } from "../types";
@@ -281,9 +281,41 @@ export function ChatPanel({
   }, [timeline, streamingText]);
 
   const isProcessing = loading || ttsLoading;
-  const hasRunningTool = timeline.some(
+
+  // Memoize expensive O(N) array operations to avoid re-running them on every streaming text token update
+  const hasRunningTool = React.useMemo(() => timeline.some(
     (item) => item.kind === "tool" && item.call.status === "running",
-  );
+  ), [timeline]);
+
+  const hasAnyTool = React.useMemo(() => timeline.some(
+    (item) => item.kind === "tool"
+  ), [timeline]);
+
+  const renderedTimeline = React.useMemo(() => {
+    return timeline.map((item) => {
+      if (item.kind === "tool") {
+        return (
+          <ToolCallBubble
+            key={item.id}
+            call={item.call}
+            onConfirm={onToolConfirm}
+          />
+        );
+      }
+
+      const msg = timelineItemToMessage(item);
+      if (!msg) return null;
+      return (
+        <MessageBubble
+          key={item.id}
+          role={msg.role}
+          text={msg.text}
+          expression={msg.expression}
+          characterName={characterName}
+        />
+      );
+    });
+  }, [timeline, onToolConfirm, characterName]);
 
   return (
     <div className="flex-1 flex flex-col bg-transparent relative h-full">
@@ -301,29 +333,7 @@ export function ChatPanel({
           </div>
         )}
 
-        {timeline.map((item) => {
-          if (item.kind === "tool") {
-            return (
-              <ToolCallBubble
-                key={item.id}
-                call={item.call}
-                onConfirm={onToolConfirm}
-              />
-            );
-          }
-
-          const msg = timelineItemToMessage(item);
-          if (!msg) return null;
-          return (
-            <MessageBubble
-              key={item.id}
-              role={msg.role}
-              text={msg.text}
-              expression={msg.expression}
-              characterName={characterName}
-            />
-          );
-        })}
+        {renderedTimeline}
 
         {/* Streaming text — always the latest assistant turn */}
         {streamingText && (
@@ -357,7 +367,7 @@ export function ChatPanel({
                   <span className="w-2 h-2 rounded-full bg-blue-400/60 animate-bounce" />
                 </div>
                 <span className="text-xs font-semibold uppercase tracking-wide">
-                  {timeline.some((item) => item.kind === "tool") ? "Continuing" : "Thinking"}
+                  {hasAnyTool ? "Continuing" : "Thinking"}
                 </span>
               </div>
             </div>


### PR DESCRIPTION
💡 **What:** 
- Wrapped the O(N) `timeline.map()` element generation in `useMemo` (`renderedTimeline`).
- Wrapped the O(N) `timeline.some()` array checks (`hasRunningTool`, `hasAnyTool`) in `useMemo`.

🎯 **Why:** 
In chat interfaces, rapidly streaming text (token-by-token) triggers frequent state updates. When expensive O(N) array operations are executed on the main message history array during the render loop, it causes significant CPU overhead and dropped frames as the history grows. By memoizing these operations against the `timeline` array reference, we avoid recreating React elements on every single token.

📊 **Impact:** 
Significantly reduces O(N) re-rendering CPU cycles and memory allocations during text streaming, providing a smoother animation and rendering experience as chat history scales.

🔬 **Measurement:**
Run `npm run dev`, populate the chat with several messages, and observe the React Developer Tools profiler / FPS drops when the assistant generates a large response. The render times for `ChatPanel` during streaming text updates should be substantially lower.

---
*PR created automatically by Jules for task [15114214530806962294](https://jules.google.com/task/15114214530806962294) started by @meet447*