### PR TITLE
⚡ Bolt: Memoize timeline O(N) operations during stream

### DIFF
--- a/src/components/ChatPanel.tsx
+++ b/src/components/ChatPanel.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect, useCallback, memo } from "react";
+import { useState, useRef, useEffect, useCallback, memo, useMemo } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import type { ChatMessage, ChatTimelineItem } from "../types";
@@ -281,9 +281,42 @@ export function ChatPanel({
   }, [timeline, streamingText]);
 
   const isProcessing = loading || ttsLoading;
-  const hasRunningTool = timeline.some(
-    (item) => item.kind === "tool" && item.call.status === "running",
-  );
+
+  // Memoize O(N) array operations over the timeline to prevent re-execution
+  // on every rapid state update (e.g., streamingText character by character).
+  const hasRunningTool = useMemo(() =>
+    timeline.some((item) => item.kind === "tool" && item.call.status === "running"),
+  [timeline]);
+
+  const hasAnyTool = useMemo(() =>
+    timeline.some((item) => item.kind === "tool"),
+  [timeline]);
+
+  const timelineElements = useMemo(() =>
+    timeline.map((item) => {
+      if (item.kind === "tool") {
+        return (
+          <ToolCallBubble
+            key={item.id}
+            call={item.call}
+            onConfirm={onToolConfirm}
+          />
+        );
+      }
+
+      const msg = timelineItemToMessage(item);
+      if (!msg) return null;
+      return (
+        <MessageBubble
+          key={item.id}
+          role={msg.role}
+          text={msg.text}
+          expression={msg.expression}
+          characterName={characterName}
+        />
+      );
+    }),
+  [timeline, onToolConfirm, characterName]);
 
   return (
     <div className="flex-1 flex flex-col bg-transparent relative h-full">
@@ -301,29 +334,7 @@ export function ChatPanel({
           </div>
         )}
 
-        {timeline.map((item) => {
-          if (item.kind === "tool") {
-            return (
-              <ToolCallBubble
-                key={item.id}
-                call={item.call}
-                onConfirm={onToolConfirm}
-              />
-            );
-          }
-
-          const msg = timelineItemToMessage(item);
-          if (!msg) return null;
-          return (
-            <MessageBubble
-              key={item.id}
-              role={msg.role}
-              text={msg.text}
-              expression={msg.expression}
-              characterName={characterName}
-            />
-          );
-        })}
+        {timelineElements}
 
         {/* Streaming text — always the latest assistant turn */}
         {streamingText && (
@@ -357,7 +368,7 @@ export function ChatPanel({
                   <span className="w-2 h-2 rounded-full bg-blue-400/60 animate-bounce" />
                 </div>
                 <span className="text-xs font-semibold uppercase tracking-wide">
-                  {timeline.some((item) => item.kind === "tool") ? "Continuing" : "Thinking"}
+                  {hasAnyTool ? "Continuing" : "Thinking"}
                 </span>
               </div>
             </div>


### PR DESCRIPTION
💡 What: Extracted array operations `timeline.map` and `timeline.some` in `ChatPanel.tsx` into `useMemo` hooks.
🎯 Why: Rapid streaming text updates cause continuous re-renders of `ChatPanel`, forcing it to re-execute O(N) map and some operations on the chat history array for every token. This wastes CPU and causes memory/GC churn.
📊 Impact: Eliminates redundant O(N) timeline iterations on every streaming text token update, making text streaming significantly smoother and saving battery/CPU.
🔬 Measurement: Verify by typing or observing streaming text - the UI should feel more responsive.

---
*PR created automatically by Jules for task [14051842711732079985](https://jules.google.com/task/14051842711732079985) started by @meet447*