### PR TITLE
⚡ Bolt: Optimize O(N) array ops in ChatPanel during streaming

### DIFF
--- a/src/components/ChatPanel.tsx
+++ b/src/components/ChatPanel.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect, useCallback, memo } from "react";
+import { useState, useRef, useEffect, useCallback, memo, useMemo } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import type { ChatMessage, ChatTimelineItem } from "../types";
@@ -281,9 +281,37 @@ export function ChatPanel({
   }, [timeline, streamingText]);
 
   const isProcessing = loading || ttsLoading;
-  const hasRunningTool = timeline.some(
+
+  // ⚡ Bolt: Cache array operations to avoid O(N) recalculations on every streaming text token update
+  const hasRunningTool = useMemo(() => timeline.some(
     (item) => item.kind === "tool" && item.call.status === "running",
-  );
+  ), [timeline]);
+
+  const hasAnyTool = useMemo(() => timeline.some((item) => item.kind === "tool"), [timeline]);
+
+  const renderedTimeline = useMemo(() => timeline.map((item) => {
+    if (item.kind === "tool") {
+      return (
+        <ToolCallBubble
+          key={item.id}
+          call={item.call}
+          onConfirm={onToolConfirm}
+        />
+      );
+    }
+
+    const msg = timelineItemToMessage(item);
+    if (!msg) return null;
+    return (
+      <MessageBubble
+        key={item.id}
+        role={msg.role}
+        text={msg.text}
+        expression={msg.expression}
+        characterName={characterName}
+      />
+    );
+  }), [timeline, characterName, onToolConfirm]);
 
   return (
     <div className="flex-1 flex flex-col bg-transparent relative h-full">
@@ -301,29 +329,7 @@ export function ChatPanel({
           </div>
         )}
 
-        {timeline.map((item) => {
-          if (item.kind === "tool") {
-            return (
-              <ToolCallBubble
-                key={item.id}
-                call={item.call}
-                onConfirm={onToolConfirm}
-              />
-            );
-          }
-
-          const msg = timelineItemToMessage(item);
-          if (!msg) return null;
-          return (
-            <MessageBubble
-              key={item.id}
-              role={msg.role}
-              text={msg.text}
-              expression={msg.expression}
-              characterName={characterName}
-            />
-          );
-        })}
+        {renderedTimeline}
 
         {/* Streaming text — always the latest assistant turn */}
         {streamingText && (
@@ -357,7 +363,7 @@ export function ChatPanel({
                   <span className="w-2 h-2 rounded-full bg-blue-400/60 animate-bounce" />
                 </div>
                 <span className="text-xs font-semibold uppercase tracking-wide">
-                  {timeline.some((item) => item.kind === "tool") ? "Continuing" : "Thinking"}
+                  {hasAnyTool ? "Continuing" : "Thinking"}
                 </span>
               </div>
             </div>


### PR DESCRIPTION
💡 **What**: Wrapped `timeline.some` checks and `timeline.map` iterations inside `ChatPanel.tsx` in `useMemo` hooks keyed to the `timeline` reference.

🎯 **Why**: During streaming responses, `ChatPanel` receives token-by-token state updates to `streamingText`. Because the component re-renders entirely on every update, these O(N) array operations were being recalculated unnecessarily on every single token, degrading performance as the chat history grew.

📊 **Impact**: Eliminates O(N) recalculation loops over the chat history on every streaming text token update, making token streaming significantly smoother and saving CPU cycles, especially for long conversations.

🔬 **Measurement**: Inspect the React Profiler while an assistant generates a long response. The `MessageBubble` elements and `timeline` iterations should no longer show as recalculating on every single keyframe update of the text stream.

---
*PR created automatically by Jules for task [4935067703184605743](https://jules.google.com/task/4935067703184605743) started by @meet447*