### PR TITLE
⚡ Bolt: Memoize timeline operations in ChatPanel to prevent O(N) re-renders during text streaming

### DIFF
--- a/pr_body.txt
+++ b/pr_body.txt
@@ -1,0 +1,4 @@
+💡 **What:** Added `useMemo` hooks to cache O(N) array operations (`timeline.some`, `timeline.map`) inside `ChatPanel.tsx`.
+🎯 **Why:** The `ChatPanel` component receives `streamingText` which updates very rapidly (token-by-token) during text generation. Previously, this caused the component to re-evaluate the entire chat history and recreate all React elements on every single keystroke/token, leading to unnecessary re-renders.
+📊 **Impact:** Prevents O(N) re-renders of the chat history elements during text generation, resulting in smoother UI performance.
+🔬 **Measurement:** Verify by running the application, engaging in a long chat session with streaming responses, and using React Developer Tools Profiler to observe that the timeline message bubbles do not re-render during the generation phase. Tests pass successfully via `npm install --no-save vitest typescript && npx vitest run`.

--- a/src/components/ChatPanel.tsx
+++ b/src/components/ChatPanel.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect, useCallback, memo } from "react";
+import { useState, useRef, useEffect, useCallback, memo, useMemo } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import type { ChatMessage, ChatTimelineItem } from "../types";
@@ -281,9 +281,45 @@ export function ChatPanel({
   }, [timeline, streamingText]);
 
   const isProcessing = loading || ttsLoading;
-  const hasRunningTool = timeline.some(
-    (item) => item.kind === "tool" && item.call.status === "running",
+
+  // ⚡ Bolt: Memoize expensive O(N) array operations on the timeline history.
+  // Because `streamingText` changes on every token, avoiding these recalculations
+  // prevents traversing the history and recreating React elements on every render.
+  const hasRunningTool = useMemo(() =>
+    timeline.some((item) => item.kind === "tool" && item.call.status === "running"),
+    [timeline]
   );
+
+  const hasAnyTool = useMemo(() =>
+    timeline.some((item) => item.kind === "tool"),
+    [timeline]
+  );
+
+  const timelineElements = useMemo(() => {
+    return timeline.map((item) => {
+      if (item.kind === "tool") {
+        return (
+          <ToolCallBubble
+            key={item.id}
+            call={item.call}
+            onConfirm={onToolConfirm}
+          />
+        );
+      }
+
+      const msg = timelineItemToMessage(item);
+      if (!msg) return null;
+      return (
+        <MessageBubble
+          key={item.id}
+          role={msg.role}
+          text={msg.text}
+          expression={msg.expression}
+          characterName={characterName}
+        />
+      );
+    });
+  }, [timeline, onToolConfirm, characterName]);
 
   return (
     <div className="flex-1 flex flex-col bg-transparent relative h-full">
@@ -301,29 +337,7 @@ export function ChatPanel({
           </div>
         )}
 
-        {timeline.map((item) => {
-          if (item.kind === "tool") {
-            return (
-              <ToolCallBubble
-                key={item.id}
-                call={item.call}
-                onConfirm={onToolConfirm}
-              />
-            );
-          }
-
-          const msg = timelineItemToMessage(item);
-          if (!msg) return null;
-          return (
-            <MessageBubble
-              key={item.id}
-              role={msg.role}
-              text={msg.text}
-              expression={msg.expression}
-              characterName={characterName}
-            />
-          );
-        })}
+        {timelineElements}
 
         {/* Streaming text — always the latest assistant turn */}
         {streamingText && (
@@ -357,7 +371,7 @@ export function ChatPanel({
                   <span className="w-2 h-2 rounded-full bg-blue-400/60 animate-bounce" />
                 </div>
                 <span className="text-xs font-semibold uppercase tracking-wide">
-                  {timeline.some((item) => item.kind === "tool") ? "Continuing" : "Thinking"}
+                  {hasAnyTool ? "Continuing" : "Thinking"}
                 </span>
               </div>
             </div>


### PR DESCRIPTION
💡 **What:** Added `useMemo` hooks to cache O(N) array operations (`timeline.some`, `timeline.map`) inside `ChatPanel.tsx`.
🎯 **Why:** The `ChatPanel` component receives `streamingText` which updates very rapidly (token-by-token) during text generation. Previously, this caused the component to re-evaluate the entire chat history and recreate all React elements on every single keystroke/token, leading to unnecessary re-renders. 
📊 **Impact:** Prevents O(N) re-renders of the chat history elements during text generation, resulting in smoother UI performance.
🔬 **Measurement:** Verify by running the application, engaging in a long chat session with streaming responses, and using React Developer Tools Profiler to observe that the timeline message bubbles do not re-render during the generation phase. Tests pass successfully via `npm install --no-save vitest typescript && npx vitest run`.

---
*PR created automatically by Jules for task [73910623637119893](https://jules.google.com/task/73910623637119893) started by @meet447*