### PR TITLE
⚡ Bolt: Memoize O(N) timeline operations to prevent unnecessary re-renders during streaming

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -21,3 +21,7 @@
 ## 2026-10-30 - Defeated React.memo via Object Recreation in Maps
 **Learning:** When rendering list items, mapping a timeline object to a new object on every render (e.g. `const msg = timelineItemToMessage(item)`) and passing it as a prop defeats `React.memo`'s shallow comparison, causing components to re-render constantly (e.g. during rapid text streaming).
 **Action:** Always pass primitive values extracted from the generated object, or pass the original stable item directly to memoized child components to ensure `React.memo` behaves efficiently and prevents O(N) re-renders.
+
+## 2024-05-18 - Defeating React List Re-renders during Rapid Updates
+**Learning:** In React list components (e.g. Chat history), `timeline.map()` and `timeline.some()` operations inside the render block cause O(N) recreations of arrays and objects on every state update. When dealing with rapid updates like token-by-token streaming, this forces React to spend significant cycles allocating memory and recreating JSX elements, even if `React.memo` is used on child components.
+**Action:** Wrap expensive O(N) array operations (like `.map()` or `.some()`) on the main history array in `useMemo` keyed to the history array reference (`[timeline]`). This avoids O(N) list traversal and JSX recreation on every streaming update, significantly boosting rendering performance.

--- a/pr_body.txt
+++ b/pr_body.txt
@@ -1,0 +1,7 @@
+💡 What: Wrapped `timeline.map` and `timeline.some` in `useMemo` hooks inside `ChatPanel.tsx`. Added inline documentation for the hooks and logged the learning to the `.jules/bolt.md` journal.
+
+🎯 Why: During rapid state updates like LLM token streaming, traversing a long history array to check for active tools or to recreate React elements causes massive O(N) re-renders, wasting CPU cycles and leading to UI jank. Even with `React.memo` on children, recreating the JSX array forces React to perform expensive reconciliation.
+
+📊 Impact: Drastically reduces main thread CPU usage and prevents unnecessary memory allocations/garbage collection during text streaming, making the UI noticeably smoother, especially in long chat sessions.
+
+🔬 Measurement: Tests and typing successfully passed using `tsc` and `vitest`. Start the app locally with `npm run dev` and chat with the AI; observe profiling in React DevTools to confirm that `MessageBubble` elements are not being unnecessarily re-evaluated and that render time per token is significantly lower.

--- a/src/components/ChatPanel.tsx
+++ b/src/components/ChatPanel.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect, useCallback, memo } from "react";
+import { useState, useRef, useEffect, useCallback, memo, useMemo } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import type { ChatMessage, ChatTimelineItem } from "../types";
@@ -281,9 +281,43 @@ export function ChatPanel({
   }, [timeline, streamingText]);
 
   const isProcessing = loading || ttsLoading;
-  const hasRunningTool = timeline.some(
-    (item) => item.kind === "tool" && item.call.status === "running",
-  );
+
+  // ⚡ Bolt: Memoized to prevent O(N) traversal of the timeline array
+  // on every single streaming text update.
+  const hasRunningTool = useMemo(() => {
+    return timeline.some(
+      (item) => item.kind === "tool" && item.call.status === "running",
+    );
+  }, [timeline]);
+
+  // ⚡ Bolt: Memoized the mapping of the timeline to JSX elements.
+  // This prevents recreating all message and tool bubble elements on every rapid
+  // token update during streaming, avoiding massive unnecessary render overhead.
+  const renderedTimeline = useMemo(() => {
+    return timeline.map((item) => {
+      if (item.kind === "tool") {
+        return (
+          <ToolCallBubble
+            key={item.id}
+            call={item.call}
+            onConfirm={onToolConfirm}
+          />
+        );
+      }
+
+      const msg = timelineItemToMessage(item);
+      if (!msg) return null;
+      return (
+        <MessageBubble
+          key={item.id}
+          role={msg.role}
+          text={msg.text}
+          expression={msg.expression}
+          characterName={characterName}
+        />
+      );
+    });
+  }, [timeline, onToolConfirm, characterName]);
 
   return (
     <div className="flex-1 flex flex-col bg-transparent relative h-full">
@@ -301,29 +335,7 @@ export function ChatPanel({
           </div>
         )}
 
-        {timeline.map((item) => {
-          if (item.kind === "tool") {
-            return (
-              <ToolCallBubble
-                key={item.id}
-                call={item.call}
-                onConfirm={onToolConfirm}
-              />
-            );
-          }
-
-          const msg = timelineItemToMessage(item);
-          if (!msg) return null;
-          return (
-            <MessageBubble
-              key={item.id}
-              role={msg.role}
-              text={msg.text}
-              expression={msg.expression}
-              characterName={characterName}
-            />
-          );
-        })}
+        {renderedTimeline}
 
         {/* Streaming text — always the latest assistant turn */}
         {streamingText && (


### PR DESCRIPTION
💡 What: Wrapped `timeline.map` and `timeline.some` in `useMemo` hooks inside `ChatPanel.tsx`. Added inline documentation for the hooks and logged the learning to the `.jules/bolt.md` journal.

🎯 Why: During rapid state updates like LLM token streaming, traversing a long history array to check for active tools or to recreate React elements causes massive O(N) re-renders, wasting CPU cycles and leading to UI jank. Even with `React.memo` on children, recreating the JSX array forces React to perform expensive reconciliation.

📊 Impact: Drastically reduces main thread CPU usage and prevents unnecessary memory allocations/garbage collection during text streaming, making the UI noticeably smoother, especially in long chat sessions.

🔬 Measurement: Tests and typing successfully passed using `tsc` and `vitest`. Start the app locally with `npm run dev` and chat with the AI; observe profiling in React DevTools to confirm that `MessageBubble` elements are not being unnecessarily re-evaluated and that render time per token is significantly lower.

---
*PR created automatically by Jules for task [8757605931944031197](https://jules.google.com/task/8757605931944031197) started by @meet447*