### PR TITLE
Docs: README centers ACP agents for chat (not LLM APIs)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ Meuxe is a local-first AI companion desktop app built with **Tauri 2** (Rust bac
 |---|---|---|
 | `src/` | TypeScript/React | Vite frontend (React 19, Tailwind, Three.js, PixiJS/Live2D) |
 | `src-tauri/` | Rust | Tauri 2 shell — desktop window, system tray, Whisper voice, commands |
-| `crates/meuxe-core/` | Rust | Core logic — LLM client, memory, sessions, characters, TTS, tools |
+| `crates/meuxe-core/` | Rust | Core logic — persona, memory, sessions, characters, TTS |
 
 ### Running in headless Cloud VM
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,7 +60,7 @@ On Linux without a display, `npm run dev` exercises the frontend; full `npm run 
 
 - `src/` — React (Vite) frontend
 - `src-tauri/` — Tauri shell and Rust commands
-- `crates/meuxe-core/` — shared Rust logic (LLM, memory, state, and related services)
+- `crates/meuxe-core/` — shared Rust logic (persona, memory, sessions, TTS; chat backend is ACP in `src-tauri`)
 
 ## Questions
 

--- a/README.md
+++ b/README.md
@@ -66,11 +66,6 @@ npm ci
 npm run tauri dev
 ```
 
-On first launch, complete onboarding (companion, voice, then **install/link your CLI agent**). Without a configured ACP agent, the UI runs but chat will not respond.
-
-For Cursor Cloud agents and repeatable setup details, see
-[`docs/cloud-agent-environment.md`](docs/cloud-agent-environment.md).
-
 ### Production build
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
 
-A **desktop companion**—a character on your screen who remembers you, speaks, and grows with you over time. Built with [**Tauri 2**](https://v2.tauri.app/) (Rust + React). Memories and relationship state stay on your machine unless you connect optional cloud AI or voice services.
+A **desktop companion**—a character on your screen who remembers you, speaks, and grows with you over time. Built with [**Tauri 2**](https://v2.tauri.app/) (Rust + React). Chat runs through your **ACP CLI agent** (Claude Code, Codex, OpenCode, or custom); memories, persona, and relationship state stay on your machine. Optional cloud **TTS** only if you enable it.
 
-Product direction: [`docs/DIRECTION.md`](docs/DIRECTION.md) · Roadmap: [`docs/ROADMAP.md`](docs/ROADMAP.md)
+Product direction: [`docs/DIRECTION.md`](docs/DIRECTION.md) · Roadmap: [`docs/ROADMAP.md`](docs/ROADMAP.md) · ACP presets: [`docs/acp-agents.md`](docs/acp-agents.md)
 
 ![Meuxe demo](assets/demo.png)
 
@@ -13,6 +13,8 @@ Product direction: [`docs/DIRECTION.md`](docs/DIRECTION.md) · Roadmap: [`docs/R
 
 - [Features](#features)
 - [Quick start](#quick-start)
+- [ACP agents (chat)](#acp-agents-chat)
+- [Providers (optional)](#providers-optional)
 - [Development](#development)
 - [Releases](#releases)
 - [Contributing](#contributing)
@@ -23,15 +25,16 @@ Product direction: [`docs/DIRECTION.md`](docs/DIRECTION.md) · Roadmap: [`docs/R
 
 ### Companion core
 
+- **ACP-backed chat** — Meuxe is the [Agent Client Protocol](https://agentclientprotocol.com) client; reasoning runs in the CLI agent you install and select
 - **Layered characters** — written as `.yaml` and `.md` files (`soul.md`, `style.md`, `rules.md`, etc.)
 - **Session history** — local persistence of chats
 - **Local long-term memory** — semantic, episodic, and reflection-style memories (local storage)
 - **Relationship state** — trust, affection, mood, and energy evolve over time
-- **Expression-aware streaming** — parses LLM output for emotion tags in real time (`<<expression>>`)
+- **Expression-aware streaming** — parses agent replies for emotion tags in real time (`<<expression>>`)
 
 ### Interaction
 
-- **Streaming chat** — real-time text over ACP-backed agent sessions
+- **Streaming chat** — real-time text over ACP agent sessions
 - **Speech subtitles** — per-sentence captions on the main stage and in mini mode while TTS plays
 - **Parallel TTS** — synthesizes speech segments in parallel for lower latency
 - **Voice input** — microphone capture, VAD, and optional Whisper-based transcription
@@ -52,6 +55,7 @@ Product direction: [`docs/DIRECTION.md`](docs/DIRECTION.md) · Roadmap: [`docs/R
 - **Node.js** 22 recommended (see [`.nvmrc`](.nvmrc))
 - **Rust** 1.88.0 with **Cargo** (pinned in [`rust-toolchain.toml`](rust-toolchain.toml); see [Tauri prerequisites](https://v2.tauri.app/start/prerequisites/) for OS-specific packages)
 - **Linux:** WebKitGTK and related dev packages (the same set [used in CI](.github/workflows/release.yml) is a good reference)
+- **An ACP agent** for chat — pick one during onboarding or in Settings → Agent (see [ACP agents (chat)](#acp-agents-chat))
 
 ### Install and run (development)
 
@@ -62,6 +66,8 @@ npm ci
 npm run tauri dev
 ```
 
+On first launch, complete onboarding (companion, voice, then **install/link your CLI agent**). Without a configured ACP agent, the UI runs but chat will not respond.
+
 For Cursor Cloud agents and repeatable setup details, see
 [`docs/cloud-agent-environment.md`](docs/cloud-agent-environment.md).
 
@@ -71,20 +77,33 @@ For Cursor Cloud agents and repeatable setup details, see
 npm run tauri build
 ```
 
+## ACP agents (chat)
+
+Meuxe does **not** embed an OpenAI-compatible LLM client for chat. Every message goes to a subprocess speaking **ACP**:
+
+| Preset | Typical install |
+|--------|-------------------|
+| **OpenCode** | `opencode` CLI (`npm i -g opencode-ai`), launched as `opencode acp` |
+| **Claude Code** | `npx -y @agentclientprotocol/claude-agent-acp@latest` |
+| **Codex** | `npx -y @agentclientprotocol/codex-acp@latest` |
+| **Custom** | Any ACP agent — command and args in Settings |
+
+Before each turn, Meuxe writes persona, memory, and relationship context under `companion-home/` in your app data directory and uses that tree as the agent working directory. Details: [`docs/companion-home.md`](docs/companion-home.md) and [`docs/acp-agents.md`](docs/acp-agents.md).
+
 ## Providers (optional)
 
-You choose which services to use, if any:
+You choose which optional services to use:
 
-- **Chat (ACP)** — companion reasoning runs in your configured CLI agent (Claude Code, Codex, OpenCode, or custom ACP). Install and pick the agent in Settings → Agent; nothing runs until you complete onboarding.
-- **TTS** — built-in Meuxe TTS (no key), plus ElevenLabs and OpenAI TTS when configured.
+- **Chat** — always via your **ACP CLI agent** (see above). No separate “LLM API” setting in Meuxe.
+- **TTS** — built-in Meuxe TTS (no key), plus ElevenLabs and OpenAI TTS when configured in Settings → Voice.
 
 ## Project structure
 
 ```text
 Meuxe/
 ├── src/                 # React (Vite) frontend
-├── src-tauri/           # Tauri shell and Rust commands
-├── crates/meuxe-core/    # Shared Rust logic (LLM, memory, state, …)
+├── src-tauri/           # Tauri shell, ACP client, Rust commands
+├── crates/meuxe-core/   # Shared Rust logic (persona, memory, sessions, TTS, …)
 ├── characters/          # Local companion profiles
 ├── models/              # Live2D and VRM assets
 └── data/                # Local session and memory data (created at runtime)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -13,7 +13,7 @@ Include enough detail to reproduce or understand the issue (steps, affected vers
 
 ## Scope
 
-This project is a **desktop application** (Tauri). Reports about third-party services you configure (LLM or TTS providers, API keys stored locally on your machine) are generally out of scope unless they expose a defect in **this** codebase.
+This project is a **desktop application** (Tauri). Reports about third-party services you configure (ACP CLI agents, TTS providers, API keys stored locally on your machine) are generally out of scope unless they expose a defect in **this** codebase.
 
 ## Supported versions
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

After the ACP-only chat merge, the README still mentioned LLM in a few places and buried ACP under a short Providers bullet. This PR makes the product story explicit on the landing doc.

## Changes

- **README** — ACP in the intro; new **ACP agents (chat)** section with preset table; prerequisites and quick-start note that chat requires a CLI agent; clarified Providers (no separate LLM API in Meuxe); fixed expression/streaming and `meuxe-core` descriptions
- **AGENTS.md** / **CONTRIBUTING.md** — core crate description matches ACP architecture
- **SECURITY.md** — third-party scope mentions ACP agents instead of generic LLM

## Testing

Docs only — no code changes.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d59a7d6f-6caf-4e25-9ce6-cbc1787f599b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d59a7d6f-6caf-4e25-9ce6-cbc1787f599b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

