### PR TITLE
feat(agents): global-first ACP CLI discovery

### DIFF
--- a/docs/acp-agents.md
+++ b/docs/acp-agents.md
@@ -2,11 +2,21 @@
 
 Chat runs only through the [Agent Client Protocol](https://agentclientprotocol.com). Meuxe is the ACP **client**; the preset picks which **agent** subprocess to spawn.
 
-| Preset | Launch command | Notes |
-|--------|----------------|--------|
-| `opencode` | `opencode acp` | [OpenCode](https://opencode.ai) — install the `opencode` CLI (e.g. `npm i -g opencode-ai`). Registry: [agentclientprotocol/registry/opencode](https://github.com/agentclientprotocol/registry/tree/main/opencode). |
-| `claude` | `npx -y @agentclientprotocol/claude-agent-acp@latest` | Claude Code via official ACP adapter. |
-| `codex` | `npx -y @agentclientprotocol/codex-acp@latest` | OpenAI Codex via official ACP adapter. |
-| `custom` | User-defined command + args | For other registry agents or local builds. |
+## Resolution order (global-first)
+
+For each preset, Meuxe picks the first match:
+
+1. **System / global** — executable on `PATH` or common locations (`~/.local/bin`, npm global `bin`, `$NPM_CONFIG_PREFIX/bin`, etc.)
+2. **Meuxe local fallback** — `{app_data}/agents/npm/bin/` (in-app “Install local fallback”)
+3. **npx** — Claude and Codex only, when Node/npx is available and no binary was found
+
+| Preset | System binary name | Global install example |
+|--------|-------------------|-------------------------|
+| `opencode` | `opencode` | `npm i -g opencode-ai` |
+| `claude` | `claude-agent-acp` | `npm i -g @agentclientprotocol/claude-agent-acp` |
+| `codex` | `codex-acp` | `npm i -g @agentclientprotocol/codex-acp` |
+| `custom` | User-defined command + args | Your PATH or full path |
+
+OpenCode is launched as `{binary} acp`. Claude/Codex adapters are launched as a single executable when found globally.
 
 Persona and memory context are written under `data_dir/companion-home/` before each turn; the session working directory is that tree.

--- a/scripts/onboarding-demo/mock-tauri.ts
+++ b/scripts/onboarding-demo/mock-tauri.ts
@@ -44,7 +44,9 @@ export async function invoke<T>(cmd: string, args?: Record<string, unknown>): Pr
           managed_install: false,
           system_path: true,
           needs_node: false,
-          detail: "Demo: agent ready.",
+          detail: "Demo: using system agent.",
+          install_source: "system",
+          system_command: "/usr/local/bin/opencode",
         },
       } as T;
     case "agent_setup_install":

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -29,3 +29,6 @@ bytes = "1.11.1"
 chrono = { version = "0.4", features = ["serde"] }
 agent-client-protocol = "2"
 shell-words = "1.1.1"
+
+[dev-dependencies]
+tempfile = "3"

--- a/src-tauri/src/acp/run.rs
+++ b/src-tauri/src/acp/run.rs
@@ -63,34 +63,22 @@ Follow all expression-tag rules in the persona for avatar reactions.\n\n\
     Ok(())
 }
 
-pub fn resolve_acp_agent(config: &AgentConfig, data_dir: &Path) -> Result<AcpAgent, String> {
+pub async fn resolve_acp_agent(config: &AgentConfig, data_dir: &Path) -> Result<AcpAgent, String> {
     match config.preset.as_str() {
         "opencode" => {
-            if let Some(managed) =
-                crate::commands::agent_setup::resolve_managed_bin(data_dir, "opencode")
-            {
-                let path = managed.to_string_lossy().into_owned();
-                AcpAgent::from_args([path, "acp".to_string()]).map_err(|e| e.to_string())
-            } else {
-                AcpAgent::from_args(["opencode", "acp"]).map_err(|e| e.to_string())
-            }
+            let args = crate::commands::agent_setup::resolve_opencode_argv(data_dir).await;
+            AcpAgent::from_args(args).map_err(|e| e.to_string())
         }
         "claude" => {
-            if let Some(managed) =
-                crate::commands::agent_setup::resolve_managed_bin(data_dir, "claude-agent-acp")
-            {
-                let path = managed.to_string_lossy().into_owned();
-                AcpAgent::from_args([path]).map_err(|e| e.to_string())
+            if let Some(args) = crate::commands::agent_setup::resolve_claude_argv(data_dir).await {
+                AcpAgent::from_args(args).map_err(|e| e.to_string())
             } else {
                 Ok(AcpAgent::claude_agent())
             }
         }
         "codex" => {
-            if let Some(managed) =
-                crate::commands::agent_setup::resolve_managed_bin(data_dir, "codex-acp")
-            {
-                let path = managed.to_string_lossy().into_owned();
-                AcpAgent::from_args([path]).map_err(|e| e.to_string())
+            if let Some(args) = crate::commands::agent_setup::resolve_codex_argv(data_dir).await {
+                AcpAgent::from_args(args).map_err(|e| e.to_string())
             } else {
                 Ok(AcpAgent::codex())
             }
@@ -124,7 +112,7 @@ pub async fn run_acp_chat_stream(params: RunAcpChatStreamParams) -> Result<(), S
     ensure_companion_home(&state.data_dir).map_err(|e| e.to_string())?;
     write_companion_home_context(&companion_home, &persona_context).map_err(|e| e.to_string())?;
 
-    let agent = resolve_acp_agent(&agent_config, &state.data_dir)?;
+    let agent = resolve_acp_agent(&agent_config, &state.data_dir).await?;
     let user_id = derive_user_id_from_state(&state)?;
 
     let app_emit = app.clone();

--- a/src-tauri/src/commands/agent_setup.rs
+++ b/src-tauri/src/commands/agent_setup.rs
@@ -8,6 +8,15 @@ use tokio::time::timeout;
 
 const NPM_INSTALL_TIMEOUT: Duration = Duration::from_secs(300);
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentInstallSource {
+    System,
+    Managed,
+    Npx,
+    None,
+}
+
 #[derive(Debug, Clone, Serialize)]
 pub struct AcpPrerequisitesStatus {
     pub node_available: bool,
@@ -20,10 +29,14 @@ pub struct AcpPrerequisitesStatus {
 pub struct AgentPresetSetupStatus {
     pub preset: String,
     pub ready: bool,
+    /// Meuxe app-data npm prefix install exists.
     pub managed_install: bool,
+    /// A CLI was found on the user/system PATH (or standard global locations).
     pub system_path: bool,
     pub needs_node: bool,
     pub detail: String,
+    pub install_source: AgentInstallSource,
+    pub system_command: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -52,7 +65,149 @@ pub fn resolve_managed_bin(data_dir: &Path, name: &str) -> Option<PathBuf> {
         managed_npm_bin_dir(data_dir).join(name),
         managed_npm_modules_bin_dir(data_dir).join(name),
     ];
-    candidates.into_iter().find(|p| p.is_file())
+    candidates.into_iter().find(|p| is_executable_file(p))
+}
+
+/// Program name on PATH for each preset (system / global install).
+pub fn preset_system_binary_name(preset: &str) -> Option<&'static str> {
+    match preset {
+        "opencode" => Some("opencode"),
+        "claude" => Some("claude-agent-acp"),
+        "codex" => Some("codex-acp"),
+        _ => None,
+    }
+}
+
+fn candidate_filenames(program: &str) -> Vec<String> {
+    let names = vec![program.to_string()];
+    #[cfg(windows)]
+    {
+        for ext in [".exe", ".cmd", ".bat"] {
+            names.push(format!("{program}{ext}"));
+        }
+    }
+    names
+}
+
+fn is_executable_file(path: &Path) -> bool {
+    if !path.is_file() {
+        return false;
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        if let Ok(meta) = path.metadata() {
+            return meta.permissions().mode() & 0o111 != 0;
+        }
+        false
+    }
+    #[cfg(not(unix))]
+    {
+        true
+    }
+}
+
+/// Extra directories where global npm / user CLIs commonly live (before scanning PATH).
+fn global_cli_search_dirs() -> Vec<PathBuf> {
+    let mut dirs = Vec::new();
+    if let Ok(prefix) = std::env::var("NPM_CONFIG_PREFIX") {
+        dirs.push(PathBuf::from(prefix).join("bin"));
+    }
+    if let Ok(home) = std::env::var("HOME") {
+        let home = PathBuf::from(home);
+        dirs.push(home.join(".local").join("bin"));
+        dirs.push(home.join(".npm-global").join("bin"));
+        dirs.push(home.join("bin"));
+    }
+    #[cfg(windows)]
+    if let Ok(appdata) = std::env::var("APPDATA") {
+        dirs.push(PathBuf::from(appdata).join("npm"));
+    }
+    dirs
+}
+
+/// Find an executable on PATH and common global install locations.
+pub fn find_executable_on_path(program: &str) -> Option<PathBuf> {
+    let mut search_dirs: Vec<PathBuf> = global_cli_search_dirs();
+    if let Some(path_var) = std::env::var_os("PATH") {
+        search_dirs.extend(std::env::split_paths(&path_var));
+    }
+
+    for dir in search_dirs {
+        for name in candidate_filenames(program) {
+            let candidate = dir.join(&name);
+            if is_executable_file(&candidate) {
+                return Some(candidate);
+            }
+        }
+    }
+    None
+}
+
+pub fn resolve_system_bin(preset: &str) -> Option<PathBuf> {
+    let name = preset_system_binary_name(preset)?;
+    find_executable_on_path(name)
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AgentResolution {
+    pub source: AgentInstallSource,
+    pub executable: Option<PathBuf>,
+}
+
+/// Global system install first, then Meuxe-managed fallback, then npx (Claude/Codex only).
+pub async fn resolve_agent(data_dir: &Path, preset: &str) -> AgentResolution {
+    let prerequisites = check_prerequisites().await;
+
+    if let Some(system) = resolve_system_bin(preset) {
+        return AgentResolution {
+            source: AgentInstallSource::System,
+            executable: Some(system),
+        };
+    }
+
+    if let Some(name) = preset_system_binary_name(preset) {
+        if let Some(managed) = resolve_managed_bin(data_dir, name) {
+            return AgentResolution {
+                source: AgentInstallSource::Managed,
+                executable: Some(managed),
+            };
+        }
+    }
+
+    match preset {
+        "claude" | "codex" if prerequisites.npx_available => AgentResolution {
+            source: AgentInstallSource::Npx,
+            executable: None,
+        },
+        _ => AgentResolution {
+            source: AgentInstallSource::None,
+            executable: None,
+        },
+    }
+}
+
+/// argv for spawning the agent (system → managed → bare name on PATH).
+pub async fn resolve_opencode_argv(data_dir: &Path) -> Vec<String> {
+    let resolution = resolve_agent(data_dir, "opencode").await;
+    match resolution.executable {
+        Some(path) => vec![path.to_string_lossy().into_owned(), "acp".into()],
+        None => vec!["opencode".into(), "acp".into()],
+    }
+}
+
+pub async fn resolve_claude_argv(data_dir: &Path) -> Option<Vec<String>> {
+    let resolution = resolve_agent(data_dir, "claude").await;
+    resolution
+        .executable
+        .map(|p| vec![p.to_string_lossy().into_owned()])
+}
+
+pub async fn resolve_codex_argv(data_dir: &Path) -> Option<Vec<String>> {
+    let resolution = resolve_agent(data_dir, "codex").await;
+    resolution
+        .executable
+        .map(|p| vec![p.to_string_lossy().into_owned()])
 }
 
 fn trim_version(stdout: &[u8]) -> Option<String> {
@@ -109,88 +264,91 @@ pub async fn check_prerequisites() -> AcpPrerequisitesStatus {
     }
 }
 
-fn managed_install_present(data_dir: &Path, name: &str) -> bool {
-    resolve_managed_bin(data_dir, name).is_some()
+fn status_from_resolution(preset: &str, resolution: AgentResolution) -> AgentPresetSetupStatus {
+    let managed_install = resolution.source == AgentInstallSource::Managed;
+    let system_path = resolution.source == AgentInstallSource::System;
+    let ready = resolution.source != AgentInstallSource::None;
+    let system_command = resolution
+        .executable
+        .as_ref()
+        .map(|p| p.to_string_lossy().into_owned());
+
+    let (needs_node, detail) = match preset {
+        "opencode" => {
+            let needs_node = resolution.source == AgentInstallSource::None;
+            let detail = match resolution.source {
+                AgentInstallSource::System => format!(
+                    "Using OpenCode on your system: {}",
+                    system_command.clone().unwrap_or_else(|| "opencode".into())
+                ),
+                AgentInstallSource::Managed => {
+                    "Using OpenCode from Meuxe app folder (local fallback).".into()
+                }
+                AgentInstallSource::None => {
+                    "Install OpenCode globally (e.g. npm i -g opencode-ai) or use the local fallback installer.".into()
+                }
+                AgentInstallSource::Npx => unreachable!(),
+            };
+            (needs_node, detail)
+        }
+        "claude" => {
+            let needs_node = resolution.source == AgentInstallSource::None;
+            let detail = match resolution.source {
+                AgentInstallSource::System => format!(
+                    "Using Claude ACP adapter on your system: {}",
+                    system_command.clone().unwrap_or_default()
+                ),
+                AgentInstallSource::Managed => {
+                    "Using Claude ACP adapter from Meuxe app folder (local fallback).".into()
+                }
+                AgentInstallSource::Npx => {
+                    "No global adapter found — will run via npx on chat (install globally for a fixed version).".into()
+                }
+                AgentInstallSource::None => {
+                    "Install Node.js, then npm i -g @agentclientprotocol/claude-agent-acp or use the local fallback.".into()
+                }
+            };
+            (needs_node, detail)
+        }
+        "codex" => {
+            let needs_node = resolution.source == AgentInstallSource::None;
+            let detail = match resolution.source {
+                AgentInstallSource::System => format!(
+                    "Using Codex ACP adapter on your system: {}",
+                    system_command.clone().unwrap_or_default()
+                ),
+                AgentInstallSource::Managed => {
+                    "Using Codex ACP adapter from Meuxe app folder (local fallback).".into()
+                }
+                AgentInstallSource::Npx => {
+                    "No global adapter found — will run via npx on chat (install globally for a fixed version).".into()
+                }
+                AgentInstallSource::None => {
+                    "Install Node.js, then npm i -g @agentclientprotocol/codex-acp or use the local fallback.".into()
+                }
+            };
+            (needs_node, detail)
+        }
+        _ => (false, String::new()),
+    };
+
+    AgentPresetSetupStatus {
+        preset: preset.to_string(),
+        ready,
+        managed_install,
+        system_path,
+        needs_node,
+        detail,
+        install_source: resolution.source,
+        system_command,
+    }
 }
 
 pub async fn check_preset(data_dir: &Path, preset: &str) -> AgentPresetSetupStatus {
-    let prerequisites = check_prerequisites().await;
-
     match preset {
-        "opencode" => {
-            let managed_install = managed_install_present(data_dir, "opencode");
-            let system_path = command_ok("opencode", &["--version"]).await;
-            let ready = managed_install || system_path;
-            let needs_node = !managed_install && !prerequisites.node_available;
-            let detail = if ready {
-                if managed_install {
-                    "OpenCode is installed for Meuxe.".into()
-                } else {
-                    "OpenCode found on your PATH.".into()
-                }
-            } else if needs_node {
-                "Install Node.js, then use Install to add OpenCode.".into()
-            } else {
-                "OpenCode not found. Use Install to set it up.".into()
-            };
-            AgentPresetSetupStatus {
-                preset: preset.to_string(),
-                ready,
-                managed_install,
-                system_path,
-                needs_node,
-                detail,
-            }
-        }
-        "claude" => {
-            let managed_install = managed_install_present(data_dir, "claude-agent-acp");
-            let system_path = prerequisites.npx_available;
-            let ready = managed_install || system_path;
-            let needs_node = !prerequisites.node_available;
-            let detail = if ready {
-                if managed_install {
-                    "Claude ACP adapter installed for Meuxe.".into()
-                } else {
-                    "Node/npx available — adapter will run via npx on first chat.".into()
-                }
-            } else if needs_node {
-                "Install Node.js (includes npx), then install the Claude adapter.".into()
-            } else {
-                "Install the Claude ACP adapter.".into()
-            };
-            AgentPresetSetupStatus {
-                preset: preset.to_string(),
-                ready,
-                managed_install,
-                system_path,
-                needs_node,
-                detail,
-            }
-        }
-        "codex" => {
-            let managed_install = managed_install_present(data_dir, "codex-acp");
-            let system_path = prerequisites.npx_available;
-            let ready = managed_install || system_path;
-            let needs_node = !prerequisites.node_available;
-            let detail = if ready {
-                if managed_install {
-                    "Codex ACP adapter installed for Meuxe.".into()
-                } else {
-                    "Node/npx available — adapter will run via npx on first chat.".into()
-                }
-            } else if needs_node {
-                "Install Node.js (includes npx), then install the Codex adapter.".into()
-            } else {
-                "Install the Codex ACP adapter.".into()
-            };
-            AgentPresetSetupStatus {
-                preset: preset.to_string(),
-                ready,
-                managed_install,
-                system_path,
-                needs_node,
-                detail,
-            }
+        "opencode" | "claude" | "codex" => {
+            let resolution = resolve_agent(data_dir, preset).await;
+            status_from_resolution(preset, resolution)
         }
         "custom" => AgentPresetSetupStatus {
             preset: preset.to_string(),
@@ -199,6 +357,8 @@ pub async fn check_preset(data_dir: &Path, preset: &str) -> AgentPresetSetupStat
             system_path: false,
             needs_node: false,
             detail: "You will provide the agent command.".into(),
+            install_source: AgentInstallSource::None,
+            system_command: None,
         },
         other => AgentPresetSetupStatus {
             preset: other.to_string(),
@@ -207,6 +367,8 @@ pub async fn check_preset(data_dir: &Path, preset: &str) -> AgentPresetSetupStat
             system_path: false,
             needs_node: false,
             detail: format!("Unknown preset: {other}"),
+            install_source: AgentInstallSource::None,
+            system_command: None,
         },
     }
 }
@@ -257,7 +419,7 @@ pub async fn install_preset(
     let prerequisites = check_prerequisites().await;
     if !prerequisites.node_available {
         return Err(
-            "Node.js is required. Install it from https://nodejs.org (LTS), then try again.".into(),
+            "Node.js is required for the local fallback install. Install it from https://nodejs.org (LTS), or install the agent globally via npm.".into(),
         );
     }
 
@@ -311,4 +473,62 @@ pub async fn agent_setup_install(
     preset: String,
 ) -> Result<AgentSetupStatusResponse, String> {
     install_preset(&state.data_dir, &preset).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    #[test]
+    fn find_executable_on_path_discovers_file() {
+        let tmp = TempDir::new().unwrap();
+        let bin = tmp.path().join("meuxe-test-cli");
+        fs::write(&bin, b"#!/bin/sh\n").unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            fs::set_permissions(&bin, fs::Permissions::from_mode(0o755)).unwrap();
+        }
+
+        let original = std::env::var_os("PATH").unwrap();
+        let new_path = format!("{}:{}", tmp.path().display(), original.to_string_lossy());
+        std::env::set_var("PATH", new_path);
+
+        let found = find_executable_on_path("meuxe-test-cli");
+        assert_eq!(found, Some(bin));
+    }
+
+    #[test]
+    fn resolution_prefers_system_over_managed() {
+        let tmp = TempDir::new().unwrap();
+        let data_dir = tmp.path().join("data");
+        let managed_bin = managed_npm_bin_dir(&data_dir);
+        fs::create_dir_all(&managed_bin).unwrap();
+        let managed = managed_bin.join("opencode");
+        fs::write(&managed, b"").unwrap();
+
+        let system_tmp = TempDir::new().unwrap();
+        let system_bin = system_tmp.path().join("opencode");
+        fs::write(&system_bin, b"#!/bin/sh\n").unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            fs::set_permissions(&system_bin, fs::Permissions::from_mode(0o755)).unwrap();
+        }
+        let original = std::env::var_os("PATH").unwrap();
+        std::env::set_var(
+            "PATH",
+            format!(
+                "{}:{}",
+                system_tmp.path().display(),
+                original.to_string_lossy()
+            ),
+        );
+
+        let system = resolve_system_bin("opencode");
+        assert!(system.is_some());
+        assert_ne!(system.unwrap(), managed);
+    }
 }

--- a/src/api/tauri.ts
+++ b/src/api/tauri.ts
@@ -58,6 +58,8 @@ export interface AgentSetupStatusResponse {
     system_path: boolean;
     needs_node: boolean;
     detail: string;
+    install_source: "system" | "managed" | "npx" | "none";
+    system_command: string | null;
   };
 }
 

--- a/src/components/agents/AgentSetupPanel.tsx
+++ b/src/components/agents/AgentSetupPanel.tsx
@@ -67,33 +67,38 @@ export function AgentSetupPanel({
   if (preset === "custom") return null;
 
   const title = ACP_AGENT_PRESETS[preset].title;
+  const agent = status?.agent;
+  const usingSystem = agent?.install_source === "system";
+  const usingManaged = agent?.install_source === "managed";
+  const usingNpx = agent?.install_source === "npx";
 
   return (
     <div className="rounded-2xl border border-slate-200/90 bg-slate-50/80 p-4">
       <div className="flex flex-wrap items-center justify-between gap-2">
         <span className="text-xs font-semibold text-slate-600">
-          {friendly ? "Quick setup" : "Setup"}
+          {friendly ? "Agent on your system" : "Agent CLI"}
         </span>
         {loading && <span className="text-xs text-slate-400">Checking…</span>}
       </div>
 
-      {status && !loading && (
+      {status && !loading && agent && (
         <div className="mt-3 space-y-3">
           <div className="flex flex-wrap gap-2">
-            <StatusPill ok={status.agent.ready} label={status.agent.ready ? `${title} ready` : `${title} needed`} />
+            <StatusPill ok={agent.ready} label={agent.ready ? `${title} ready` : `${title} needed`} />
+            {usingSystem && <StatusPill ok label="System PATH" />}
+            {usingManaged && <StatusPill ok label="Meuxe fallback" />}
+            {usingNpx && <StatusPill ok label="via npx" />}
             <StatusPill ok={status.prerequisites.node_available} label="Node.js" />
             {status.prerequisites.node_version && (
               <span className="text-[11px] text-slate-400">{status.prerequisites.node_version}</span>
             )}
-            <StatusPill ok={status.prerequisites.npx_available} label="npx" muted={!status.prerequisites.npx_available} />
           </div>
 
-          {!status.agent.ready && !friendly && (
-            <p className="text-sm text-slate-600 leading-snug">{status.agent.detail}</p>
-          )}
-          {!status.agent.ready && friendly && (
-            <p className="text-sm text-slate-600 leading-snug">
-              Tap install once — we&apos;ll set this up in your Meuxe folder.
+          <p className="text-sm text-slate-600 leading-snug">{agent.detail}</p>
+
+          {friendly && !agent.ready && (
+            <p className="text-sm text-slate-500 leading-snug">
+              Install the CLI globally (npm), or use the local fallback below.
             </p>
           )}
 
@@ -107,28 +112,28 @@ export function AgentSetupPanel({
                 Install Node.js
               </button>
             )}
-            {status.prerequisites.node_available && !status.agent.ready && (
+            {status.prerequisites.node_available && !agent.ready && (
               <button
                 type="button"
                 onClick={runInstall}
                 disabled={installing}
                 className="rounded-xl bg-violet-600 px-3.5 py-2 text-sm font-semibold text-white hover:bg-violet-700 disabled:opacity-50"
               >
-                {installing ? "Installing…" : `Install ${title}`}
+                {installing ? "Installing…" : "Install local fallback"}
               </button>
             )}
-            {status.prerequisites.node_available && status.agent.ready && !status.agent.managed_install && (
+            {status.prerequisites.node_available && agent.ready && usingSystem && (
+              <span className="text-xs font-semibold text-emerald-700">Using your global install</span>
+            )}
+            {status.prerequisites.node_available && agent.ready && !usingSystem && (
               <button
                 type="button"
                 onClick={runInstall}
                 disabled={installing}
                 className="rounded-xl border border-violet-200 bg-white px-3.5 py-2 text-sm font-semibold text-violet-800 hover:bg-violet-50 disabled:opacity-50"
               >
-                {installing ? "Installing…" : "Install into Meuxe folder"}
+                {installing ? "Installing…" : "Install local fallback"}
               </button>
-            )}
-            {status.agent.ready && status.agent.managed_install && (
-              <span className="text-xs font-semibold text-emerald-700">Ready in Meuxe folder</span>
             )}
           </div>
         </div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Agent presets now use a **global-first** resolution order (system PATH and common global install dirs), with Meuxe’s app-data npm prefix as **local fallback** only.

### Resolution order
1. **System** — `opencode`, `claude-agent-acp`, or `codex-acp` on `PATH` plus `~/.local/bin`, `~/.npm-global/bin`, `$NPM_CONFIG_PREFIX/bin`, etc.
2. **Managed** — `{app_data}/agents/npm/bin/` (in-app “Install local fallback”)
3. **npx** — Claude/Codex only when no binary is found

### API / UI
- Status includes `install_source` (`system` | `managed` | `npx` | `none`) and `system_command` when applicable.
- Setup panel shows **System PATH** vs **Meuxe fallback** vs **via npx**, with updated copy.
- Chat spawn (`resolve_acp_agent`) uses the same order (async).

### Docs
- `docs/acp-agents.md` updated with global install examples.

## Test plan
- [x] `cargo test agent_setup`
- [x] `npm test`
- [ ] Manual: global `opencode` on PATH → Settings shows “Using your global install”; chat works without local fallback
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-727e392f-3ec9-4659-a81a-98cccc65cad3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-727e392f-3ec9-4659-a81a-98cccc65cad3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

